### PR TITLE
 Atom Snippets for common libraries.

### DIFF
--- a/snippets/FCNPC.cson
+++ b/snippets/FCNPC.cson
@@ -1,0 +1,655 @@
+# Atom Snippets from Sublime Text Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia.
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'FCNPC_OnCreate':
+    'prefix': 'FCNPC_OnCreate'
+    'body': 'FCNPC_OnCreate(${1:npcid})'
+
+  'FCNPC_OnDestroy':
+    'prefix': 'FCNPC_OnDestroy'
+    'body': 'FCNPC_OnDestroy(${1:npcid})'
+
+  'FCNPC_OnSpawn':
+    'prefix': 'FCNPC_OnSpawn'
+    'body': 'FCNPC_OnSpawn(${1:npcid})'
+
+  'FCNPC_OnRespawn':
+    'prefix': 'FCNPC_OnRespawn'
+    'body': 'FCNPC_OnRespawn(${1:npcid})'
+
+  'FCNPC_OnDeath':
+    'prefix': 'FCNPC_OnDeath'
+    'body': 'FCNPC_OnDeath(${1:npcid}, ${2:killerid}, ${3:weaponid})'
+
+  'FCNPC_OnVehicleEntryComplete':
+    'prefix': 'FCNPC_OnVehicleEntryComplete'
+    'body': 'FCNPC_OnVehicleEntryComplete(${1:npcid}, ${2:vehicleid}, ${3:seat})'
+
+  'FCNPC_OnVehicleExitComplete':
+    'prefix': 'FCNPC_OnVehicleExitComplete'
+    'body': 'FCNPC_OnVehicleExitComplete(${1:npcid})'
+
+  'FCNPC_OnReachDestination':
+    'prefix': 'FCNPC_OnReachDestination'
+    'body': 'FCNPC_OnReachDestination(${1:npcid})'
+
+  'FCNPC_OnFinishPlayback':
+    'prefix': 'FCNPC_OnFinishPlayback'
+    'body': 'FCNPC_OnFinishPlayback(${1:npcid})'
+
+  'FCNPC_OnTakeDamage':
+    'prefix': 'FCNPC_OnTakeDamage'
+    'body': 'FCNPC_OnTakeDamage(${1:npcid}, ${2:damagerid}, ${3:weaponid}, ${4:bodypart}, ${5:Float:health_loss})'
+
+  'FCNPC_OnGiveDamage':
+    'prefix': 'FCNPC_OnGiveDamage'
+    'body': 'FCNPC_OnGiveDamage(${1:npcid}, ${2:issuerid}, ${3:weaponid}, ${4:bodypart}, ${5:Float:health_loss})'
+
+  'FCNPC_OnVehicleTakeDamage':
+    'prefix': 'FCNPC_OnVehicleTakeDamage'
+    'body': 'FCNPC_OnVehicleTakeDamage(${1:npcid}, ${2:damagerid}, ${3:vehicleid}, ${4:weaponid}, ${5:Float:x}, ${6:Float:y}, ${7:Float:z})'
+
+  'FCNPC_OnFinishNodePoint':
+    'prefix': 'FCNPC_OnFinishNodePoint'
+    'body': 'FCNPC_OnFinishNodePoint(${1:npcid}, ${2:point})'
+
+  'FCNPC_OnChangeNode':
+    'prefix': 'FCNPC_OnChangeNode'
+    'body': 'FCNPC_OnChangeNode(${1:npcid}, ${2:nodeid})'
+
+  'FCNPC_OnFinishNode':
+    'prefix': 'FCNPC_OnFinishNode'
+    'body': 'FCNPC_OnFinishNode(${1:npcid})'
+
+  'FCNPC_OnStreamIn':
+    'prefix': 'FCNPC_OnStreamIn'
+    'body': 'FCNPC_OnStreamIn(${1:npcid}, ${2:forplayerid})'
+
+  'FCNPC_OnStreamOut':
+    'prefix': 'FCNPC_OnStreamOut'
+    'body': 'FCNPC_OnStreamOut(${1:npcid}, ${2:forplayerid})'
+
+  'FCNPC_OnUpdate':
+    'prefix': 'FCNPC_OnUpdate'
+    'body': 'FCNPC_OnUpdate(${1:npcid})'
+
+  'FCNPC_OnFinishMovePath':
+    'prefix': 'FCNPC_OnFinishMovePath'
+    'body': 'FCNPC_OnFinishMovePath(${1:npcid}, ${2:pathid})'
+
+  'FCNPC_OnFinishMovePathPoint':
+    'prefix': 'FCNPC_OnFinishMovePathPoint'
+    'body': 'FCNPC_OnFinishMovePathPoint(${1:npcid}, ${2:pathid}, ${3:pointid})'
+
+  'FCNPC_SetUpdateRate':
+    'prefix': 'FCNPC_SetUpdateRate'
+    'body': 'FCNPC_SetUpdateRate(${1:rate})'
+
+  'FCNPC_InitMapAndreas':
+    'prefix': 'FCNPC_InitMapAndreas'
+    'body': 'FCNPC_InitMapAndreas(${1:address})'
+
+  'FCNPC_Create':
+    'prefix': 'FCNPC_Create'
+    'body': 'FCNPC_Create(${1:name[]})'
+
+  'FCNPC_Destroy':
+    'prefix': 'FCNPC_Destroy'
+    'body': 'FCNPC_Destroy(${1:npcid})'
+
+  'FCNPC_Spawn':
+    'prefix': 'FCNPC_Spawn'
+    'body': 'FCNPC_Spawn(${1:npcid}, ${2:skinid}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'FCNPC_Respawn':
+    'prefix': 'FCNPC_Respawn'
+    'body': 'FCNPC_Respawn(${1:npcid})'
+
+  'FCNPC_IsSpawned':
+    'prefix': 'FCNPC_IsSpawned'
+    'body': 'FCNPC_IsSpawned(${1:npcid})'
+
+  'FCNPC_Kill':
+    'prefix': 'FCNPC_Kill'
+    'body': 'FCNPC_Kill(${1:npcid})'
+
+  'FCNPC_IsDead':
+    'prefix': 'FCNPC_IsDead'
+    'body': 'FCNPC_IsDead(${1:npcid})'
+
+  'FCNPC_IsValid':
+    'prefix': 'FCNPC_IsValid'
+    'body': 'FCNPC_IsValid(${1:npcid})'
+
+  'FCNPC_IsStreamedIn':
+    'prefix': 'FCNPC_IsStreamedIn'
+    'body': 'FCNPC_IsStreamedIn(${1:npcid}, ${2:forplayerid})'
+
+  'FCNPC_IsStreamedForAnyone':
+    'prefix': 'FCNPC_IsStreamedForAnyone'
+    'body': 'FCNPC_IsStreamedForAnyone(${1:npcid})'
+
+  'FCNPC_SetPosition':
+    'prefix': 'FCNPC_SetPosition'
+    'body': 'FCNPC_SetPosition(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_GivePosition':
+    'prefix': 'FCNPC_GivePosition'
+    'body': 'FCNPC_GivePosition(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_GetPosition':
+    'prefix': 'FCNPC_GetPosition'
+    'body': 'FCNPC_GetPosition(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_SetAngle':
+    'prefix': 'FCNPC_SetAngle'
+    'body': 'FCNPC_SetAngle(${1:npcid}, ${2:Float:angle})'
+
+  'FCNPC_GiveAngle':
+    'prefix': 'FCNPC_GiveAngle'
+    'body': 'FCNPC_GiveAngle(${1:npcid}, ${2:Float:angle})'
+
+  'FCNPC_SetAngleToPos':
+    'prefix': 'FCNPC_SetAngleToPos'
+    'body': 'FCNPC_SetAngleToPos(${1:npcid}, ${2:Float:x}, ${3:Float:y})'
+
+  'FCNPC_SetAngleToPlayer':
+    'prefix': 'FCNPC_SetAngleToPlayer'
+    'body': 'FCNPC_SetAngleToPlayer(${1:npcid}, ${2:playerid})'
+
+  'FCNPC_GetAngle':
+    'prefix': 'FCNPC_GetAngle'
+    'body': 'FCNPC_GetAngle(${1:npcid})'
+
+  'FCNPC_SetQuaternion':
+    'prefix': 'FCNPC_SetQuaternion'
+    'body': 'FCNPC_SetQuaternion(${1:npcid}, ${2:Float:w}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'FCNPC_GiveQuaternion':
+    'prefix': 'FCNPC_GiveQuaternion'
+    'body': 'FCNPC_GiveQuaternion(${1:npcid}, ${2:Float:w}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'FCNPC_GetQuaternion':
+    'prefix': 'FCNPC_GetQuaternion'
+    'body': 'FCNPC_GetQuaternion(${1:npcid}, ${2:Float:w}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'FCNPC_SetVelocity':
+    'prefix': 'FCNPC_SetVelocity'
+    'body': 'FCNPC_SetVelocity(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:bool:update_pos = false})'
+
+  'FCNPC_GiveVelocity':
+    'prefix': 'FCNPC_GiveVelocity'
+    'body': 'FCNPC_GiveVelocity(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:bool:update_pos = false})'
+
+  'FCNPC_GetVelocity':
+    'prefix': 'FCNPC_GetVelocity'
+    'body': 'FCNPC_GetVelocity(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_SetInterior':
+    'prefix': 'FCNPC_SetInterior'
+    'body': 'FCNPC_SetInterior(${1:npcid}, ${2:interiorid})'
+
+  'FCNPC_GetInterior':
+    'prefix': 'FCNPC_GetInterior'
+    'body': 'FCNPC_GetInterior(${1:npcid})'
+
+  'FCNPC_SetVirtualWorld':
+    'prefix': 'FCNPC_SetVirtualWorld'
+    'body': 'FCNPC_SetVirtualWorld(${1:npcid}, ${2:worldid})'
+
+  'FCNPC_GetVirtualWorld':
+    'prefix': 'FCNPC_GetVirtualWorld'
+    'body': 'FCNPC_GetVirtualWorld(${1:npcid})'
+
+  'FCNPC_SetHealth':
+    'prefix': 'FCNPC_SetHealth'
+    'body': 'FCNPC_SetHealth(${1:npcid}, ${2:Float:health})'
+
+  'FCNPC_GiveHealth':
+    'prefix': 'FCNPC_GiveHealth'
+    'body': 'FCNPC_GiveHealth(${1:npcid}, ${2:Float:health})'
+
+  'FCNPC_GetHealth':
+    'prefix': 'FCNPC_GetHealth'
+    'body': 'FCNPC_GetHealth(${1:npcid})'
+
+  'FCNPC_SetArmour':
+    'prefix': 'FCNPC_SetArmour'
+    'body': 'FCNPC_SetArmour(${1:npcid}, ${2:Float:armour})'
+
+  'FCNPC_GiveArmour':
+    'prefix': 'FCNPC_GiveArmour'
+    'body': 'FCNPC_GiveArmour(${1:npcid}, ${2:Float:armour})'
+
+  'FCNPC_GetArmour':
+    'prefix': 'FCNPC_GetArmour'
+    'body': 'FCNPC_GetArmour(${1:npcid})'
+
+  'FCNPC_SetInvulnerable':
+    'prefix': 'FCNPC_SetInvulnerable'
+    'body': 'FCNPC_SetInvulnerable(${1:npcid}, ${2:bool:invulnerable = true})'
+
+  'FCNPC_IsInvulnerable':
+    'prefix': 'FCNPC_IsInvulnerable'
+    'body': 'FCNPC_IsInvulnerable(${1:npcid})'
+
+  'FCNPC_SetSkin':
+    'prefix': 'FCNPC_SetSkin'
+    'body': 'FCNPC_SetSkin(${1:npcid}, ${2:skinid})'
+
+  'FCNPC_GetSkin':
+    'prefix': 'FCNPC_GetSkin'
+    'body': 'FCNPC_GetSkin(${1:npcid})'
+
+  'FCNPC_SetWeapon':
+    'prefix': 'FCNPC_SetWeapon'
+    'body': 'FCNPC_SetWeapon(${1:npcid}, ${2:weaponid})'
+
+  'FCNPC_GetWeapon':
+    'prefix': 'FCNPC_GetWeapon'
+    'body': 'FCNPC_GetWeapon(${1:npcid})'
+
+  'FCNPC_SetAmmo':
+    'prefix': 'FCNPC_SetAmmo'
+    'body': 'FCNPC_SetAmmo(${1:npcid}, ${2:ammo})'
+
+  'FCNPC_GiveAmmo':
+    'prefix': 'FCNPC_GiveAmmo'
+    'body': 'FCNPC_GiveAmmo(${1:npcid}, ${2:ammo})'
+
+  'FCNPC_GetAmmo':
+    'prefix': 'FCNPC_GetAmmo'
+    'body': 'FCNPC_GetAmmo(${1:npcid})'
+
+  'FCNPC_SetWeaponSkillLevel':
+    'prefix': 'FCNPC_SetWeaponSkillLevel'
+    'body': 'FCNPC_SetWeaponSkillLevel(${1:npcid}, ${2:skill}, ${3:level})'
+
+  'FCNPC_GiveWeaponSkillLevel':
+    'prefix': 'FCNPC_GiveWeaponSkillLevel'
+    'body': 'FCNPC_GiveWeaponSkillLevel(${1:npcid}, ${2:skill}, ${3:level})'
+
+  'FCNPC_GetWeaponSkillLevel':
+    'prefix': 'FCNPC_GetWeaponSkillLevel'
+    'body': 'FCNPC_GetWeaponSkillLevel(${1:npcid}, ${2:skill})'
+
+  'FCNPC_SetWeaponState':
+    'prefix': 'FCNPC_SetWeaponState'
+    'body': 'FCNPC_SetWeaponState(${1:npcid}, ${2:weaponstate})'
+
+  'FCNPC_GetWeaponState':
+    'prefix': 'FCNPC_GetWeaponState'
+    'body': 'FCNPC_GetWeaponState(${1:npcid})'
+
+  'FCNPC_SetWeaponReloadTime':
+    'prefix': 'FCNPC_SetWeaponReloadTime'
+    'body': 'FCNPC_SetWeaponReloadTime(${1:npcid}, ${2:weaponid}, ${3:time})'
+
+  'FCNPC_GetWeaponReloadTime':
+    'prefix': 'FCNPC_GetWeaponReloadTime'
+    'body': 'FCNPC_GetWeaponReloadTime(${1:npcid}, ${2:weaponid})'
+
+  'FCNPC_SetWeaponShootTime':
+    'prefix': 'FCNPC_SetWeaponShootTime'
+    'body': 'FCNPC_SetWeaponShootTime(${1:npcid}, ${2:weaponid}, ${3:time})'
+
+  'FCNPC_GetWeaponShootTime':
+    'prefix': 'FCNPC_GetWeaponShootTime'
+    'body': 'FCNPC_GetWeaponShootTime(${1:npcid}, ${2:weaponid})'
+
+  'FCNPC_SetWeaponClipSize':
+    'prefix': 'FCNPC_SetWeaponClipSize'
+    'body': 'FCNPC_SetWeaponClipSize(${1:npcid}, ${2:weaponid}, ${3:size})'
+
+  'FCNPC_GetWeaponClipSize':
+    'prefix': 'FCNPC_GetWeaponClipSize'
+    'body': 'FCNPC_GetWeaponClipSize(${1:npcid}, ${2:weaponid})'
+
+  'FCNPC_SetWeaponAccuracy':
+    'prefix': 'FCNPC_SetWeaponAccuracy'
+    'body': 'FCNPC_SetWeaponAccuracy(${1:npcid}, ${2:weaponid}, ${3:Float:accuracy})'
+
+  'FCNPC_GetWeaponAccuracy':
+    'prefix': 'FCNPC_GetWeaponAccuracy'
+    'body': 'FCNPC_GetWeaponAccuracy(${1:npcid}, ${2:weaponid})'
+
+  'FCNPC_SetWeaponInfo':
+    'prefix': 'FCNPC_SetWeaponInfo'
+    'body': 'FCNPC_SetWeaponInfo(${1:npcid}, ${2:weaponid}, ${3:reload_time = -1}, ${4:shoot_time = -1}, ${5:clip_size = -1}, ${6:Float:accuracy = 1.0})'
+
+  'FCNPC_GetWeaponInfo':
+    'prefix': 'FCNPC_GetWeaponInfo'
+    'body': 'FCNPC_GetWeaponInfo(${1:npcid}, ${2:weaponid}, ${3:reload_time = -1}, ${4:shoot_time = -1}, ${5:clip_size = -1}, ${6:Float:accuracy = 1.0})'
+
+  'FCNPC_SetWeaponDefaultInfo':
+    'prefix': 'FCNPC_SetWeaponDefaultInfo'
+    'body': 'FCNPC_SetWeaponDefaultInfo(${1:weaponid}, ${2:reload_time = -1}, ${3:shoot_time = -1}, ${4:clip_size = -1}, ${5:Float:accuracy = 1.0})'
+
+  'FCNPC_GetWeaponDefaultInfo':
+    'prefix': 'FCNPC_GetWeaponDefaultInfo'
+    'body': 'FCNPC_GetWeaponDefaultInfo(${1:weaponid}, ${2:reload_time = -1}, ${3:shoot_time = -1}, ${4:clip_size = -1}, ${5:Float:accuracy = 1.0})'
+
+  'FCNPC_SetKeys':
+    'prefix': 'FCNPC_SetKeys'
+    'body': 'FCNPC_SetKeys(${1:npcid}, ${2:ud_analog}, ${3:lr_analog}, ${4:keys})'
+
+  'FCNPC_GetKeys':
+    'prefix': 'FCNPC_GetKeys'
+    'body': 'FCNPC_GetKeys(${1:npcid}, ${2:ud_analog}, ${3:lr_analog}, ${4:keys})'
+
+  'FCNPC_SetSpecialAction':
+    'prefix': 'FCNPC_SetSpecialAction'
+    'body': 'FCNPC_SetSpecialAction(${1:npcid}, ${2:actionid})'
+
+  'FCNPC_GetSpecialAction':
+    'prefix': 'FCNPC_GetSpecialAction'
+    'body': 'FCNPC_GetSpecialAction(${1:npcid})'
+
+  'FCNPC_SetAnimation':
+    'prefix': 'FCNPC_SetAnimation'
+    'body': 'FCNPC_SetAnimation(${1:npcid}, ${2:animationid}, ${3:Float:fDelta = 4.1}, ${4:loop = 0}, ${5:lockx = 1}, ${6:locky = 1}, ${7:freeze = 0}, ${8:time = 1})'
+
+  'FCNPC_SetAnimationByName':
+    'prefix': 'FCNPC_SetAnimationByName'
+    'body': 'FCNPC_SetAnimationByName(${1:npcid}, ${2:name[]}, ${3:Float:fDelta = 4.1}, ${4:loop = 0}, ${5:lockx = 1}, ${6:locky = 1}, ${7:freeze = 0}, ${8:time = 1})'
+
+  'FCNPC_ResetAnimation':
+    'prefix': 'FCNPC_ResetAnimation'
+    'body': 'FCNPC_ResetAnimation(${1:npcid})'
+
+  'FCNPC_GetAnimation':
+    'prefix': 'FCNPC_GetAnimation'
+    'body': 'FCNPC_GetAnimation(${1:npcid}, ${2:animationid = 0}, ${3:Float:fDelta = 4.1}, ${4:loop = 0}, ${5:lockx = 1}, ${6:locky = 1}, ${7:freeze = 0}, ${8:time = 1})'
+
+  'FCNPC_ApplyAnimation':
+    'prefix': 'FCNPC_ApplyAnimation'
+    'body': 'FCNPC_ApplyAnimation(${1:npcid}, ${2:animlib[]}, ${3:animname[]}, ${4:Float:fDelta = 4.1}, ${5:loop = 0}, ${6:lockx = 1}, ${7:locky = 1}, ${8:freeze = 0}, ${9:time = 1})'
+
+  'FCNPC_ClearAnimations':
+    'prefix': 'FCNPC_ClearAnimations'
+    'body': 'FCNPC_ClearAnimations(${1:npcid})'
+
+  'FCNPC_SetFightingStyle':
+    'prefix': 'FCNPC_SetFightingStyle'
+    'body': 'FCNPC_SetFightingStyle(${1:npcid}, ${2:style})'
+
+  'FCNPC_GetFightingStyle':
+    'prefix': 'FCNPC_GetFightingStyle'
+    'body': 'FCNPC_GetFightingStyle(${1:npcid})'
+
+  'FCNPC_ToggleReloading':
+    'prefix': 'FCNPC_ToggleReloading'
+    'body': 'FCNPC_ToggleReloading(${1:npcid}, ${2:bool:toggle})'
+
+  'FCNPC_ToggleInfiniteAmmo':
+    'prefix': 'FCNPC_ToggleInfiniteAmmo'
+    'body': 'FCNPC_ToggleInfiniteAmmo(${1:npcid}, ${2:bool:toggle})'
+
+  'FCNPC_GoTo':
+    'prefix': 'FCNPC_GoTo'
+    'body': 'FCNPC_GoTo(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:type = MOVE_TYPE_AUTO}, ${6:Float:speed = MOVE_SPEED_AUTO}, ${7:bool:UseMapAndreas = false}, ${8:Float:radius = 0.0}, ${9:bool:setangle = true})'
+
+  'FCNPC_GoToPlayer':
+    'prefix': 'FCNPC_GoToPlayer'
+    'body': 'FCNPC_GoToPlayer(${1:npcid}, ${2:playerid}, ${3:type = MOVE_TYPE_AUTO}, ${4:Float:speed = MOVE_SPEED_AUTO}, ${5:bool:UseMapAndreas = false}, ${6:Float:radius = 0.0}, ${7:bool:setangle = true})'
+
+  'FCNPC_Stop':
+    'prefix': 'FCNPC_Stop'
+    'body': 'FCNPC_Stop(${1:npcid})'
+
+  'FCNPC_IsMoving':
+    'prefix': 'FCNPC_IsMoving'
+    'body': 'FCNPC_IsMoving(${1:npcid})'
+
+  'FCNPC_IsMovingAtPlayer':
+    'prefix': 'FCNPC_IsMovingAtPlayer'
+    'body': 'FCNPC_IsMovingAtPlayer(${1:npcid}, ${2:playerid})'
+
+  'FCNPC_AimAt':
+    'prefix': 'FCNPC_AimAt'
+    'body': 'FCNPC_AimAt(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:bool:shoot = false}, ${6:shoot_delay = -1}, ${7:bool:setangle = true})'
+
+  'FCNPC_AimAtPlayer':
+    'prefix': 'FCNPC_AimAtPlayer'
+    'body': 'FCNPC_AimAtPlayer(${1:npcid}, ${2:playerid}, ${3:bool:shoot = false}, ${4:shoot_delay = -1}, ${5:bool:setangle = true})'
+
+  'FCNPC_StopAim':
+    'prefix': 'FCNPC_StopAim'
+    'body': 'FCNPC_StopAim(${1:npcid})'
+
+  'FCNPC_MeleeAttack':
+    'prefix': 'FCNPC_MeleeAttack'
+    'body': 'FCNPC_MeleeAttack(${1:npcid}, ${2:delay = -1}, ${3:bool:fightstyle = false})'
+
+  'FCNPC_StopAttack':
+    'prefix': 'FCNPC_StopAttack'
+    'body': 'FCNPC_StopAttack(${1:npcid})'
+
+  'FCNPC_IsAttacking':
+    'prefix': 'FCNPC_IsAttacking'
+    'body': 'FCNPC_IsAttacking(${1:npcid})'
+
+  'FCNPC_IsAiming':
+    'prefix': 'FCNPC_IsAiming'
+    'body': 'FCNPC_IsAiming(${1:npcid})'
+
+  'FCNPC_IsAimingAtPlayer':
+    'prefix': 'FCNPC_IsAimingAtPlayer'
+    'body': 'FCNPC_IsAimingAtPlayer(${1:npcid}, ${2:playerid})'
+
+  'FCNPC_IsShooting':
+    'prefix': 'FCNPC_IsShooting'
+    'body': 'FCNPC_IsShooting(${1:npcid})'
+
+  'FCNPC_IsReloading':
+    'prefix': 'FCNPC_IsReloading'
+    'body': 'FCNPC_IsReloading(${1:npcid})'
+
+  'FCNPC_EnterVehicle':
+    'prefix': 'FCNPC_EnterVehicle'
+    'body': 'FCNPC_EnterVehicle(${1:npcid}, ${2:vehicleid}, ${3:seatid}, ${4:type = MOVE_TYPE_WALK})'
+
+  'FCNPC_ExitVehicle':
+    'prefix': 'FCNPC_ExitVehicle'
+    'body': 'FCNPC_ExitVehicle(${1:npcid})'
+
+  'FCNPC_PutInVehicle':
+    'prefix': 'FCNPC_PutInVehicle'
+    'body': 'FCNPC_PutInVehicle(${1:npcid}, ${2:vehicleid}, ${3:seatid})'
+
+  'FCNPC_RemoveFromVehicle':
+    'prefix': 'FCNPC_RemoveFromVehicle'
+    'body': 'FCNPC_RemoveFromVehicle(${1:npcid})'
+
+  'FCNPC_GetVehicleID':
+    'prefix': 'FCNPC_GetVehicleID'
+    'body': 'FCNPC_GetVehicleID(${1:npcid})'
+
+  'FCNPC_GetVehicleSeat':
+    'prefix': 'FCNPC_GetVehicleSeat'
+    'body': 'FCNPC_GetVehicleSeat(${1:npcid})'
+
+  'FCNPC_SetVehicleSiren':
+    'prefix': 'FCNPC_SetVehicleSiren'
+    'body': 'FCNPC_SetVehicleSiren(${1:npcid}, ${2:bool:status})'
+
+  'FCNPC_IsVehicleSiren':
+    'prefix': 'FCNPC_IsVehicleSiren'
+    'body': 'FCNPC_IsVehicleSiren(${1:npcid})'
+
+  'FCNPC_SetVehicleHealth':
+    'prefix': 'FCNPC_SetVehicleHealth'
+    'body': 'FCNPC_SetVehicleHealth(${1:npcid}, ${2:Float:health})'
+
+  'FCNPC_GetVehicleHealth':
+    'prefix': 'FCNPC_GetVehicleHealth'
+    'body': 'FCNPC_GetVehicleHealth(${1:npcid})'
+
+  'FCNPC_SetVehicleHydraThrusters':
+    'prefix': 'FCNPC_SetVehicleHydraThrusters'
+    'body': 'FCNPC_SetVehicleHydraThrusters(${1:npcid}, ${2:direction})'
+
+  'FCNPC_GetVehicleHydraThrusters':
+    'prefix': 'FCNPC_GetVehicleHydraThrusters'
+    'body': 'FCNPC_GetVehicleHydraThrusters(${1:npcid})'
+
+  'FCNPC_SetVehicleGearState':
+    'prefix': 'FCNPC_SetVehicleGearState'
+    'body': 'FCNPC_SetVehicleGearState(${1:npcid}, ${2:gear_state})'
+
+  'FCNPC_GetVehicleGearState':
+    'prefix': 'FCNPC_GetVehicleGearState'
+    'body': 'FCNPC_GetVehicleGearState(${1:npcid})'
+
+  'FCNPC_SetSurfingOffsets':
+    'prefix': 'FCNPC_SetSurfingOffsets'
+    'body': 'FCNPC_SetSurfingOffsets(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_GiveSurfingOffsets':
+    'prefix': 'FCNPC_GiveSurfingOffsets'
+    'body': 'FCNPC_GiveSurfingOffsets(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_GetSurfingOffsets':
+    'prefix': 'FCNPC_GetSurfingOffsets'
+    'body': 'FCNPC_GetSurfingOffsets(${1:npcid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_SetSurfingVehicle':
+    'prefix': 'FCNPC_SetSurfingVehicle'
+    'body': 'FCNPC_SetSurfingVehicle(${1:npcid}, ${2:vehicleid})'
+
+  'FCNPC_GetSurfingVehicle':
+    'prefix': 'FCNPC_GetSurfingVehicle'
+    'body': 'FCNPC_GetSurfingVehicle(${1:npcid})'
+
+  'FCNPC_SetSurfingObject':
+    'prefix': 'FCNPC_SetSurfingObject'
+    'body': 'FCNPC_SetSurfingObject(${1:npcid}, ${2:objectid})'
+
+  'FCNPC_GetSurfingObject':
+    'prefix': 'FCNPC_GetSurfingObject'
+    'body': 'FCNPC_GetSurfingObject(${1:npcid})'
+
+  'FCNPC_SetSurfingPlayerObject':
+    'prefix': 'FCNPC_SetSurfingPlayerObject'
+    'body': 'FCNPC_SetSurfingPlayerObject(${1:npcid}, ${2:objectid})'
+
+  'FCNPC_GetSurfingPlayerObject':
+    'prefix': 'FCNPC_GetSurfingPlayerObject'
+    'body': 'FCNPC_GetSurfingPlayerObject(${1:npcid})'
+
+  'FCNPC_StopSurfing':
+    'prefix': 'FCNPC_StopSurfing'
+    'body': 'FCNPC_StopSurfing(${1:npcid})'
+
+  'FCNPC_StartPlayingPlayback':
+    'prefix': 'FCNPC_StartPlayingPlayback'
+    'body': 'FCNPC_StartPlayingPlayback(${1:npcid}, ${2:file[] = \"\"}, ${3:recordid = INVALID_RECORD_ID}, ${4:bool:auto_unload = false})'
+
+  'FCNPC_StopPlayingPlayback':
+    'prefix': 'FCNPC_StopPlayingPlayback'
+    'body': 'FCNPC_StopPlayingPlayback(${1:npcid})'
+
+  'FCNPC_PausePlayingPlayback':
+    'prefix': 'FCNPC_PausePlayingPlayback'
+    'body': 'FCNPC_PausePlayingPlayback(${1:npcid})'
+
+  'FCNPC_ResumePlayingPlayback':
+    'prefix': 'FCNPC_ResumePlayingPlayback'
+    'body': 'FCNPC_ResumePlayingPlayback(${1:npcid})'
+
+  'FCNPC_LoadPlayingPlayback':
+    'prefix': 'FCNPC_LoadPlayingPlayback'
+    'body': 'FCNPC_LoadPlayingPlayback(${1:file[]})'
+
+  'FCNPC_UnloadPlayingPlayback':
+    'prefix': 'FCNPC_UnloadPlayingPlayback'
+    'body': 'FCNPC_UnloadPlayingPlayback(${1:recordid})'
+
+  'FCNPC_SetPlayingPlaybackPath':
+    'prefix': 'FCNPC_SetPlayingPlaybackPath'
+    'body': 'FCNPC_SetPlayingPlaybackPath(${1:npcid}, ${2:path[]})'
+
+  'FCNPC_GetPlayingPlaybackPath':
+    'prefix': 'FCNPC_GetPlayingPlaybackPath'
+    'body': 'FCNPC_GetPlayingPlaybackPath(${1:npcid}, ${2:path[]}, ${3:const size = sizeof(path})'
+
+  'FCNPC_OpenNode':
+    'prefix': 'FCNPC_OpenNode'
+    'body': 'FCNPC_OpenNode(${1:nodeid})'
+
+  'FCNPC_CloseNode':
+    'prefix': 'FCNPC_CloseNode'
+    'body': 'FCNPC_CloseNode(${1:nodeid})'
+
+  'FCNPC_IsNodeOpen':
+    'prefix': 'FCNPC_IsNodeOpen'
+    'body': 'FCNPC_IsNodeOpen(${1:nodeid})'
+
+  'FCNPC_GetNodeType':
+    'prefix': 'FCNPC_GetNodeType'
+    'body': 'FCNPC_GetNodeType(${1:nodeid})'
+
+  'FCNPC_SetNodePoint':
+    'prefix': 'FCNPC_SetNodePoint'
+    'body': 'FCNPC_SetNodePoint(${1:nodeid}, ${2:point})'
+
+  'FCNPC_GetNodePointPosition':
+    'prefix': 'FCNPC_GetNodePointPosition'
+    'body': 'FCNPC_GetNodePointPosition(${1:nodeid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_GetNodePointCount':
+    'prefix': 'FCNPC_GetNodePointCount'
+    'body': 'FCNPC_GetNodePointCount(${1:nodeid})'
+
+  'FCNPC_GetNodeInfo':
+    'prefix': 'FCNPC_GetNodeInfo'
+    'body': 'FCNPC_GetNodeInfo(${1:nodeid}, ${2:vehnodes}, ${3:pednodes}, ${4:navinode})'
+
+  'FCNPC_PlayNode':
+    'prefix': 'FCNPC_PlayNode'
+    'body': 'FCNPC_PlayNode(${1:npcid}, ${2:nodeid}, ${3:type})'
+
+  'FCNPC_StopPlayingNode':
+    'prefix': 'FCNPC_StopPlayingNode'
+    'body': 'FCNPC_StopPlayingNode(${1:npcid})'
+
+  'FCNPC_CreateMovePath':
+    'prefix': 'FCNPC_CreateMovePath'
+    'body': 'FCNPC_CreateMovePath()'
+
+  'FCNPC_DestroyMovePath':
+    'prefix': 'FCNPC_DestroyMovePath'
+    'body': 'FCNPC_DestroyMovePath(${1:pathid})'
+
+  'FCNPC_IsValidMovePath':
+    'prefix': 'FCNPC_IsValidMovePath'
+    'body': 'FCNPC_IsValidMovePath(${1:pathid})'
+
+  'FCNPC_AddPointToPath':
+    'prefix': 'FCNPC_AddPointToPath'
+    'body': 'FCNPC_AddPointToPath(${1:pathid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'FCNPC_AddPointsToPath':
+    'prefix': 'FCNPC_AddPointsToPath'
+    'body': 'FCNPC_AddPointsToPath(${1:pathid}, ${2:Float:points[][3]}, ${3:const size = sizeof(points})'
+
+  'FCNPC_RemovePointFromPath':
+    'prefix': 'FCNPC_RemovePointFromPath'
+    'body': 'FCNPC_RemovePointFromPath(${1:pathid}, ${2:pointid})'
+
+  'FCNPC_IsValidMovePoint':
+    'prefix': 'FCNPC_IsValidMovePoint'
+    'body': 'FCNPC_IsValidMovePoint(${1:pathid}, ${2:pointid})'
+
+  'FCNPC_GetMovePoint':
+    'prefix': 'FCNPC_GetMovePoint'
+    'body': 'FCNPC_GetMovePoint(${1:pathid}, ${2:pointid}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'FCNPC_GetNumberMovePoint':
+    'prefix': 'FCNPC_GetNumberMovePoint'
+    'body': 'FCNPC_GetNumberMovePoint(${1:pathid})'
+
+  'FCNPC_GoByMovePath':
+    'prefix': 'FCNPC_GoByMovePath'
+    'body': 'FCNPC_GoByMovePath(${1:npcid}, ${2:pathid}, ${3:type = MOVE_TYPE_AUTO}, ${4:Float:speed = MOVE_SPEED_AUTO}, ${5:bool:UseMapAndreas = false}, ${6:Float:radius = 0.0}, ${7:bool:setangle = true})'

--- a/snippets/SIF.Button.pwn.cson
+++ b/snippets/SIF.Button.pwn.cson
@@ -1,0 +1,127 @@
+# SIF.Button.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'CreateButton':
+    'prefix': 'CreateButton'
+    'body': 'CreateButton(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:text[]}, ${5:world = 0}, ${6:interior = 0}, ${7:Float:areasize = 1.0}, ${8:label = 0}, ${9:labeltext[] = \"\"}, ${10:labelcolour = 0xFFFF00FF}, ${11:Float:streamdist = BTN_DEFAULT_STREAMDIST}, ${12:testlos = true})'
+
+  'DestroyButton':
+    'prefix': 'DestroyButton'
+    'body': 'DestroyButton(${1:buttonid})'
+
+  'LinkTP':
+    'prefix': 'LinkTP'
+    'body': 'LinkTP(${1:buttonid1}, ${2:buttonid2})'
+
+  'UnLinkTP':
+    'prefix': 'UnLinkTP'
+    'body': 'UnLinkTP(${1:buttonid1}, ${2:buttonid2})'
+
+  'IsValidButton':
+    'prefix': 'IsValidButton'
+    'body': 'IsValidButton(${1:buttonid})'
+
+  'GetButtonArea':
+    'prefix': 'GetButtonArea'
+    'body': 'GetButtonArea(${1:buttonid})'
+
+  'SetButtonArea':
+    'prefix': 'SetButtonArea'
+    'body': 'SetButtonArea(${1:buttonid}, ${2:areaid})'
+
+  'SetButtonLabel':
+    'prefix': 'SetButtonLabel'
+    'body': 'SetButtonLabel(${1:buttonid}, ${2:text[]}, ${3:colour = 0xFFFF00FF}, ${4:Float:range = BTN_DEFAULT_STREAMDIST}, ${5:testlos = true})'
+
+  'DestroyButtonLabel':
+    'prefix': 'DestroyButtonLabel'
+    'body': 'DestroyButtonLabel(${1:buttonid})'
+
+  'GetButtonPos':
+    'prefix': 'GetButtonPos'
+    'body': 'GetButtonPos(${1:buttonid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'SetButtonPos':
+    'prefix': 'SetButtonPos'
+    'body': 'SetButtonPos(${1:buttonid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetButtonSize':
+    'prefix': 'GetButtonSize'
+    'body': 'GetButtonSize(${1:buttonid})'
+
+  'SetButtonSize':
+    'prefix': 'SetButtonSize'
+    'body': 'SetButtonSize(${1:buttonid}, ${2:Float:size})'
+
+  'GetButtonWorld':
+    'prefix': 'GetButtonWorld'
+    'body': 'GetButtonWorld(${1:buttonid})'
+
+  'SetButtonWorld':
+    'prefix': 'SetButtonWorld'
+    'body': 'SetButtonWorld(${1:buttonid}, ${2:world})'
+
+  'GetButtonInterior':
+    'prefix': 'GetButtonInterior'
+    'body': 'GetButtonInterior(${1:buttonid})'
+
+  'SetButtonInterior':
+    'prefix': 'SetButtonInterior'
+    'body': 'SetButtonInterior(${1:buttonid}, ${2:interior})'
+
+  'GetButtonLinkedID':
+    'prefix': 'GetButtonLinkedID'
+    'body': 'GetButtonLinkedID(${1:buttonid})'
+
+  'GetButtonText':
+    'prefix': 'GetButtonText'
+    'body': 'GetButtonText(${1:buttonid}, ${2:text[]})'
+
+  'SetButtonText':
+    'prefix': 'SetButtonText'
+    'body': 'SetButtonText(${1:buttonid}, ${2:text[]})'
+
+  'SetButtonExtraData':
+    'prefix': 'SetButtonExtraData'
+    'body': 'SetButtonExtraData(${1:buttonid}, ${2:data})'
+
+  'GetButtonExtraData':
+    'prefix': 'GetButtonExtraData'
+    'body': 'GetButtonExtraData(${1:buttonid})'
+
+  'GetPlayerPressingButton':
+    'prefix': 'GetPlayerPressingButton'
+    'body': 'GetPlayerPressingButton(${1:playerid})'
+
+  'GetPlayerButtonID':
+    'prefix': 'GetPlayerButtonID'
+    'body': 'GetPlayerButtonID(${1:playerid})'
+
+  'GetPlayerButtonList':
+    'prefix': 'GetPlayerButtonList'
+    'body': 'GetPlayerButtonList(${1:playerid}, ${2:list[]}, ${3:size}, ${4:bool:validate = false})'
+
+  'GetPlayerAngleToButton':
+    'prefix': 'GetPlayerAngleToButton'
+    'body': 'GetPlayerAngleToButton(${1:playerid}, ${2:buttonid})'
+
+  'GetButtonAngleToPlayer':
+    'prefix': 'GetButtonAngleToPlayer'
+    'body': 'GetButtonAngleToPlayer(${1:playerid}, ${2:buttonid})'
+
+  'OnButtonPress':
+    'prefix': 'OnButtonPress'
+    'body': 'OnButtonPress(${1:playerid}, ${2:buttonid})'
+
+  'OnButtonRelease':
+    'prefix': 'OnButtonRelease'
+    'body': 'OnButtonRelease(${1:playerid}, ${2:buttonid})'
+
+  'OnPlayerEnterButtonArea':
+    'prefix': 'OnPlayerEnterButtonArea'
+    'body': 'OnPlayerEnterButtonArea(${1:playerid}, ${2:buttonid})'
+
+  'OnPlayerLeaveButtonArea':
+    'prefix': 'OnPlayerLeaveButtonArea'
+    'body': 'OnPlayerLeaveButtonArea(${1:playerid}, ${2:buttonid})'

--- a/snippets/SIF.Container.pwn.cson
+++ b/snippets/SIF.Container.pwn.cson
@@ -1,0 +1,103 @@
+# SIF.Container.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'CreateContainer':
+    'prefix': 'CreateContainer'
+    'body': 'CreateContainer(${1:name[]}, ${2:size}, ${3:buttonid = INVALID_BUTTON_ID})'
+
+  'DestroyContainer':
+    'prefix': 'DestroyContainer'
+    'body': 'DestroyContainer(${1:containerid}, ${2:destroyitems = true}, ${3:destroybutton = true})'
+
+  'AddItemToContainer':
+    'prefix': 'AddItemToContainer'
+    'body': 'AddItemToContainer(${1:containerid}, ${2:itemid}, ${3:playerid = INVALID_PLAYER_ID})'
+
+  'RemoveItemFromContainer':
+    'prefix': 'RemoveItemFromContainer'
+    'body': 'RemoveItemFromContainer(${1:containerid}, ${2:slotid}, ${3:playerid = INVALID_PLAYER_ID}, ${4:call = 1})'
+
+  'IsValidContainer':
+    'prefix': 'IsValidContainer'
+    'body': 'IsValidContainer(${1:containerid})'
+
+  'GetContainerButton':
+    'prefix': 'GetContainerButton'
+    'body': 'GetContainerButton(${1:containerid})'
+
+  'GetContainerName':
+    'prefix': 'GetContainerName'
+    'body': 'GetContainerName(${1:containerid}, ${2:name[]})'
+
+  'GetContainerSize':
+    'prefix': 'GetContainerSize'
+    'body': 'GetContainerSize(${1:containerid})'
+
+  'SetContainerSize':
+    'prefix': 'SetContainerSize'
+    'body': 'SetContainerSize(${1:containerid}, ${2:size})'
+
+  'GetContainerItemCount':
+    'prefix': 'GetContainerItemCount'
+    'body': 'GetContainerItemCount(${1:containerid})'
+
+  'GetContainerSlotItem':
+    'prefix': 'GetContainerSlotItem'
+    'body': 'GetContainerSlotItem(${1:containerid}, ${2:slotid})'
+
+  'IsContainerSlotUsed':
+    'prefix': 'IsContainerSlotUsed'
+    'body': 'IsContainerSlotUsed(${1:containerid}, ${2:slotid})'
+
+  'IsContainerFull':
+    'prefix': 'IsContainerFull'
+    'body': 'IsContainerFull(${1:containerid})'
+
+  'IsContainerEmpty':
+    'prefix': 'IsContainerEmpty'
+    'body': 'IsContainerEmpty(${1:containerid})'
+
+  'WillItemTypeFitInContainer':
+    'prefix': 'WillItemTypeFitInContainer'
+    'body': 'WillItemTypeFitInContainer(${1:containerid}, ${2:ItemType:itemtype})'
+
+  'GetContainerFreeSlots':
+    'prefix': 'GetContainerFreeSlots'
+    'body': 'GetContainerFreeSlots(${1:containerid})'
+
+  'GetItemContainer':
+    'prefix': 'GetItemContainer'
+    'body': 'GetItemContainer(${1:itemid})'
+
+  'GetItemContainerSlot':
+    'prefix': 'GetItemContainerSlot'
+    'body': 'GetItemContainerSlot(${1:itemid})'
+
+  'GetButtonContainer':
+    'prefix': 'GetButtonContainer'
+    'body': 'GetButtonContainer(${1:buttonid})'
+
+  'OnContainerCreate':
+    'prefix': 'OnContainerCreate'
+    'body': 'OnContainerCreate(${1:containerid})'
+
+  'OnContainerDestroy':
+    'prefix': 'OnContainerDestroy'
+    'body': 'OnContainerDestroy(${1:containerid})'
+
+  'OnItemAddToContainer':
+    'prefix': 'OnItemAddToContainer'
+    'body': 'OnItemAddToContainer(${1:containerid}, ${2:itemid}, ${3:playerid})'
+
+  'OnItemAddedToContainer':
+    'prefix': 'OnItemAddedToContainer'
+    'body': 'OnItemAddedToContainer(${1:containerid}, ${2:itemid}, ${3:playerid})'
+
+  'OnItemRemoveFromContainer':
+    'prefix': 'OnItemRemoveFromContainer'
+    'body': 'OnItemRemoveFromContainer(${1:containerid}, ${2:slotid}, ${3:playerid})'
+
+  'OnItemRemovedFromContainer':
+    'prefix': 'OnItemRemovedFromContainer'
+    'body': 'OnItemRemovedFromContainer(${1:containerid}, ${2:slotid}, ${3:playerid})'

--- a/snippets/SIF.ContainerDialog.pwn.cson
+++ b/snippets/SIF.ContainerDialog.pwn.cson
@@ -1,0 +1,47 @@
+# SIF.ContainerDialog.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'DisplayContainerInventory':
+    'prefix': 'DisplayContainerInventory'
+    'body': 'DisplayContainerInventory(${1:playerid}, ${2:containerid})'
+
+  'ClosePlayerContainer':
+    'prefix': 'ClosePlayerContainer'
+    'body': 'ClosePlayerContainer(${1:playerid}, ${2:call = false})'
+
+  'GetPlayerCurrentContainer':
+    'prefix': 'GetPlayerCurrentContainer'
+    'body': 'GetPlayerCurrentContainer(${1:playerid})'
+
+  'GetPlayerContainerSlot':
+    'prefix': 'GetPlayerContainerSlot'
+    'body': 'GetPlayerContainerSlot(${1:playerid})'
+
+  'AddContainerOption':
+    'prefix': 'AddContainerOption'
+    'body': 'AddContainerOption(${1:playerid}, ${2:option[]})'
+
+  'OnPlayerOpenContainer':
+    'prefix': 'OnPlayerOpenContainer'
+    'body': 'OnPlayerOpenContainer(${1:playerid}, ${2:containerid})'
+
+  'OnPlayerCloseContainer':
+    'prefix': 'OnPlayerCloseContainer'
+    'body': 'OnPlayerCloseContainer(${1:playerid}, ${2:containerid})'
+
+  'OnPlayerViewContainerOpt':
+    'prefix': 'OnPlayerViewContainerOpt'
+    'body': 'OnPlayerViewContainerOpt(${1:playerid}, ${2:containerid})'
+
+  'OnPlayerSelectContainerOpt':
+    'prefix': 'OnPlayerSelectContainerOpt'
+    'body': 'OnPlayerSelectContainerOpt(${1:playerid}, ${2:containerid}, ${3:option})'
+
+  'OnMoveItemToContainer':
+    'prefix': 'OnMoveItemToContainer'
+    'body': 'OnMoveItemToContainer(${1:playerid}, ${2:itemid}, ${3:containerid})'
+
+  'OnMoveItemToInventory':
+    'prefix': 'OnMoveItemToInventory'
+    'body': 'OnMoveItemToInventory(${1:playerid}, ${2:itemid}, ${3:containerid})'

--- a/snippets/SIF.Core.pwn.cson
+++ b/snippets/SIF.Core.pwn.cson
@@ -1,0 +1,55 @@
+# SIF.Core.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'IsPlayerInPlayerArea':
+    'prefix': 'IsPlayerInPlayerArea'
+    'body': 'IsPlayerInPlayerArea(${1:playerid}, ${2:targetid})'
+
+  'ShowActionText':
+    'prefix': 'ShowActionText'
+    'body': 'ShowActionText(${1:playerid}, ${2:message[]}, ${3:time=0}, ${4:width=200})'
+
+  'HideActionText':
+    'prefix': 'HideActionText'
+    'body': 'HideActionText(${1:playerid})'
+
+  'IsPlayerViewingActionText':
+    'prefix': 'IsPlayerViewingActionText'
+    'body': 'IsPlayerViewingActionText(${1:playerid})'
+
+  'sif_absoluteangle':
+    'prefix': 'sif_absoluteangle'
+    'body': 'sif_absoluteangle(${1:Float:angle})'
+
+  'sif_GetAngleToPoint':
+    'prefix': 'sif_GetAngleToPoint'
+    'body': 'sif_GetAngleToPoint(${1:Float:fPointX}, ${2:Float:fPointY}, ${3:Float:fDestX}, ${4:Float:fDestY})'
+
+  'sif_Distance':
+    'prefix': 'sif_Distance'
+    'body': 'sif_Distance(${1:Float:x1}, ${2:Float:y1}, ${3:Float:z1}, ${4:Float:x2}, ${5:Float:y2}, ${6:Float:z2})'
+
+  'sif_IsIdleAnim':
+    'prefix': 'sif_IsIdleAnim'
+    'body': 'sif_IsIdleAnim(${1:animidx})'
+
+  'sif_abs':
+    'prefix': 'sif_abs'
+    'body': 'sif_abs(${1:int})'
+
+  'sif_intdiffabs':
+    'prefix': 'sif_intdiffabs'
+    'body': 'sif_intdiffabs(${1:tick1}, ${2:tick2})'
+
+  'sif_GetTickCountDiff':
+    'prefix': 'sif_GetTickCountDiff'
+    'body': 'sif_GetTickCountDiff(${1:a}, ${2:b})'
+
+  'OnPlayerEnterPlayerArea':
+    'prefix': 'OnPlayerEnterPlayerArea'
+    'body': 'OnPlayerEnterPlayerArea(${1:playerid}, ${2:targetid})'
+
+  'OnPlayerLeavePlayerArea':
+    'prefix': 'OnPlayerLeavePlayerArea'
+    'body': 'OnPlayerLeavePlayerArea(${1:playerid}, ${2:targetid})'

--- a/snippets/SIF.Craft.pwn.cson
+++ b/snippets/SIF.Craft.pwn.cson
@@ -1,0 +1,71 @@
+# SIF.Craft.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'DefineItemCraftSet':
+    'prefix': 'DefineItemCraftSet'
+    'body': 'DefineItemCraftSet(${1:ItemType:result}, ${2:...})'
+
+  'GetCraftSetUniqueID':
+    'prefix': 'GetCraftSetUniqueID'
+    'body': 'GetCraftSetUniqueID(${1:craftset}, ${2:id[]}, ${3:maxlength = sizeof(id})'
+
+  'IsValidCraftSet':
+    'prefix': 'IsValidCraftSet'
+    'body': 'IsValidCraftSet(${1:craftset})'
+
+  'GetCraftSetIngredients':
+    'prefix': 'GetCraftSetIngredients'
+    'body': 'GetCraftSetIngredients(${1:craftset}, ${2:output[CFT_MAX_CRAFT_SET_ITEMS][e_craft_item_data]})'
+
+  'GetCraftSetItemType':
+    'prefix': 'GetCraftSetItemType'
+    'body': 'GetCraftSetItemType(${1:craftset}, ${2:index})'
+
+  'GetCraftSetItemKeep':
+    'prefix': 'GetCraftSetItemKeep'
+    'body': 'GetCraftSetItemKeep(${1:craftset}, ${2:index})'
+
+  'GetCraftSetItemCount':
+    'prefix': 'GetCraftSetItemCount'
+    'body': 'GetCraftSetItemCount(${1:craftset})'
+
+  'GetCraftSetResult':
+    'prefix': 'GetCraftSetResult'
+    'body': 'GetCraftSetResult(${1:craftset})'
+
+  'GetCraftSetTotal':
+    'prefix': 'GetCraftSetTotal'
+    'body': 'GetCraftSetTotal()'
+
+  'GetPlayerSelectedCraftItems':
+    'prefix': 'GetPlayerSelectedCraftItems'
+    'body': 'GetPlayerSelectedCraftItems(${1:playerid}, ${2:output[CFT_MAX_CRAFT_SET_ITEMS][e_selected_item_data]})'
+
+  'GetPlayerSelectedCraftItemType':
+    'prefix': 'GetPlayerSelectedCraftItemType'
+    'body': 'GetPlayerSelectedCraftItemType(${1:playerid}, ${2:index})'
+
+  'GetPlayerSelectedCraftItemID':
+    'prefix': 'GetPlayerSelectedCraftItemID'
+    'body': 'GetPlayerSelectedCraftItemID(${1:playerid}, ${2:index})'
+
+  'GetPlayerSelectedCraftItemCount':
+    'prefix': 'GetPlayerSelectedCraftItemCount'
+    'body': 'GetPlayerSelectedCraftItemCount(${1:playerid})'
+
+  'GetPlayerCraftEnvironment':
+    'prefix': 'GetPlayerCraftEnvironment'
+    'body': 'GetPlayerCraftEnvironment(${1:playerid})'
+
+  'ItemTypeResultForCraftingSet':
+    'prefix': 'ItemTypeResultForCraftingSet'
+    'body': 'ItemTypeResultForCraftingSet(${1:ItemType:itemtype})'
+
+  'OnPlayerCraft':
+    'prefix': 'OnPlayerCraft'
+    'body': 'OnPlayerCraft(${1:playerid}, ${2:craftset})'
+
+  'OnPlayerCrafted':
+    'prefix': 'OnPlayerCrafted'
+    'body': 'OnPlayerCrafted(${1:playerid}, ${2:craftset}, ${3:result})'

--- a/snippets/SIF.Debug.pwn.cson
+++ b/snippets/SIF.Debug.pwn.cson
@@ -1,0 +1,43 @@
+# SIF.Debug.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'sif_debug_register_handler':
+    'prefix': 'sif_debug_register_handler'
+    'body': 'sif_debug_register_handler(${1:name[]}, ${2:initstate = 0})'
+
+  'sif_debug_level':
+    'prefix': 'sif_debug_level'
+    'body': 'sif_debug_level(${1:handler}, ${2:level})'
+
+  'sif_debug_plevel':
+    'prefix': 'sif_debug_plevel'
+    'body': 'sif_debug_plevel(${1:playerid}, ${2:handler}, ${3:level})'
+
+  'sif_debug_print':
+    'prefix': 'sif_debug_print'
+    'body': 'sif_debug_print(${1:handler}, ${2:level}, ${3:playerid}, ${4:msg[]})'
+
+  'sif_debug_printf':
+    'prefix': 'sif_debug_printf'
+    'body': 'sif_debug_printf(${1:handler}, ${2:level}, ${3:playerid}, ${4:string[]}, ${5:va_args<>})'
+
+  'sif_debug_handler_search':
+    'prefix': 'sif_debug_handler_search'
+    'body': 'sif_debug_handler_search(${1:name[]})'
+
+  'sif_debug_get_handler_name':
+    'prefix': 'sif_debug_get_handler_name'
+    'body': 'sif_debug_get_handler_name(${1:handler}, ${2:output[]})'
+
+  'SIF_IS_VALID_HANDLER(%0)':
+    'prefix': 'SIF_IS_VALID_HANDLER(%0)'
+    'body': 'SIF_IS_VALID_HANDLER(${1:0})'
+
+  'sif_dp:%0:%1(%2)<%3>':
+    'prefix': 'sif_dp:%0:%1(%2)<%3>'
+    'body': 'sif_dp:${1:0}:${2:1}(${3:2})<${4:3}>'
+
+  'sif_d:%0:%1(%2)':
+    'prefix': 'sif_d:%0:%1(%2)'
+    'body': 'sif_d:${1:0}:${2:1}(${3:2})'

--- a/snippets/SIF.DebugLabels.pwn.cson
+++ b/snippets/SIF.DebugLabels.pwn.cson
@@ -1,0 +1,51 @@
+# SIF.DebugLabels.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'DefineDebugLabelType':
+    'prefix': 'DefineDebugLabelType'
+    'body': 'DefineDebugLabelType(${1:name[]}, ${2:colour = 0xFFFFFFFF})'
+
+  'CreateDebugLabel':
+    'prefix': 'CreateDebugLabel'
+    'body': 'CreateDebugLabel(${1:type}, ${2:entityid}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z}, ${6:string[] = \"\"}, ${7:worldid = -1}, ${8:interiorid = -1})'
+
+  'DestroyDebugLabel':
+    'prefix': 'DestroyDebugLabel'
+    'body': 'DestroyDebugLabel(${1:labelid})'
+
+  'ShowDebugLabelsForPlayer':
+    'prefix': 'ShowDebugLabelsForPlayer'
+    'body': 'ShowDebugLabelsForPlayer(${1:playerid}, ${2:type})'
+
+  'ShowAllDebugLabelsForPlayer':
+    'prefix': 'ShowAllDebugLabelsForPlayer'
+    'body': 'ShowAllDebugLabelsForPlayer(${1:playerid})'
+
+  'HideDebugLabelsForPlayer':
+    'prefix': 'HideDebugLabelsForPlayer'
+    'body': 'HideDebugLabelsForPlayer(${1:playerid}, ${2:type})'
+
+  'HideAllDebugLabelsForPlayer':
+    'prefix': 'HideAllDebugLabelsForPlayer'
+    'body': 'HideAllDebugLabelsForPlayer(${1:playerid})'
+
+  'UpdateDebugLabelString':
+    'prefix': 'UpdateDebugLabelString'
+    'body': 'UpdateDebugLabelString(${1:labelid}, ${2:string[]})'
+
+  'IsValidDebugLabel':
+    'prefix': 'IsValidDebugLabel'
+    'body': 'IsValidDebugLabel(${1:labelid})'
+
+  'SetDebugLabelPos':
+    'prefix': 'SetDebugLabelPos'
+    'body': 'SetDebugLabelPos(${1:labelid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'IsPlayerToggledDebugLabels':
+    'prefix': 'IsPlayerToggledDebugLabels'
+    'body': 'IsPlayerToggledDebugLabels(${1:playerid}, ${2:type})'
+
+  'IsPlayerToggledAllDebugLabels':
+    'prefix': 'IsPlayerToggledAllDebugLabels'
+    'body': 'IsPlayerToggledAllDebugLabels(${1:playerid})'

--- a/snippets/SIF.Door.pwn.cson
+++ b/snippets/SIF.Door.pwn.cson
@@ -1,0 +1,119 @@
+# SIF.Door.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'CreateDoor':
+    'prefix': 'CreateDoor'
+    'body': 'CreateDoor(${1:model}, ${2:buttonids[]}, ${3:Float:px}, ${4:Float:py}, ${5:Float:pz}, ${6:Float:rx}, ${7:Float:ry}, ${8:Float:rz}, ${9:Float:mpx}, ${10:Float:mpy}, ${11:Float:mpz}, ${12:Float:mrx}, ${13:Float:mry}, ${14:Float:mrz}, ${15:Float:movespeed = 1.0}, ${16:closedelay = 3000}, ${17:maxbuttons = sizeof(buttonids})'
+
+  'DestroyDoor':
+    'prefix': 'DestroyDoor'
+    'body': 'DestroyDoor(${1:doorid})'
+
+  'OpenDoor':
+    'prefix': 'OpenDoor'
+    'body': 'OpenDoor(${1:doorid})'
+
+  'CloseDoor':
+    'prefix': 'CloseDoor'
+    'body': 'CloseDoor(${1:doorid})'
+
+  'IsValidDOor':
+    'prefix': 'IsValidDOor'
+    'body': 'IsValidDOor(${1:doorid})'
+
+  'GetDoorObjectID':
+    'prefix': 'GetDoorObjectID'
+    'body': 'GetDoorObjectID(${1:doorid})'
+
+  'GetDoorModel':
+    'prefix': 'GetDoorModel'
+    'body': 'GetDoorModel(${1:doorid})'
+
+  'SetDoorModel':
+    'prefix': 'SetDoorModel'
+    'body': 'SetDoorModel(${1:doorid}, ${2:model})'
+
+  'GetDoorButton':
+    'prefix': 'GetDoorButton'
+    'body': 'GetDoorButton(${1:doorid}, ${2:slot})'
+
+  'GetDoorButtonCount':
+    'prefix': 'GetDoorButtonCount'
+    'body': 'GetDoorButtonCount(${1:doorid})'
+
+  'GetDoorCloseDelay':
+    'prefix': 'GetDoorCloseDelay'
+    'body': 'GetDoorCloseDelay(${1:doorid})'
+
+  'SetDoorCloseDelay':
+    'prefix': 'SetDoorCloseDelay'
+    'body': 'SetDoorCloseDelay(${1:doorid}, ${2:closedelay})'
+
+  'GetDoorMoveSpeed':
+    'prefix': 'GetDoorMoveSpeed'
+    'body': 'GetDoorMoveSpeed(${1:doorid})'
+
+  'SetDoorMoveSpeed':
+    'prefix': 'SetDoorMoveSpeed'
+    'body': 'SetDoorMoveSpeed(${1:doorid}, ${2:Float:movespeed})'
+
+  'GetDoorMoveSound':
+    'prefix': 'GetDoorMoveSound'
+    'body': 'GetDoorMoveSound(${1:doorid})'
+
+  'SetDoorMoveSound':
+    'prefix': 'SetDoorMoveSound'
+    'body': 'SetDoorMoveSound(${1:doorid}, ${2:movesound})'
+
+  'GetDoorStopSound':
+    'prefix': 'GetDoorStopSound'
+    'body': 'GetDoorStopSound(${1:doorid})'
+
+  'SetDoorStopSound':
+    'prefix': 'SetDoorStopSound'
+    'body': 'SetDoorStopSound(${1:doorid}, ${2:stopsound})'
+
+  'GetDoorPos':
+    'prefix': 'GetDoorPos'
+    'body': 'GetDoorPos(${1:doorid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'SetDoorPos':
+    'prefix': 'SetDoorPos'
+    'body': 'SetDoorPos(${1:doorid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetDoorRot':
+    'prefix': 'GetDoorRot'
+    'body': 'GetDoorRot(${1:doorid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'SetDoorRot':
+    'prefix': 'SetDoorRot'
+    'body': 'SetDoorRot(${1:doorid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'GetDoorMovePos':
+    'prefix': 'GetDoorMovePos'
+    'body': 'GetDoorMovePos(${1:doorid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'SetDoorMovePos':
+    'prefix': 'SetDoorMovePos'
+    'body': 'SetDoorMovePos(${1:doorid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetDoorMoveRot':
+    'prefix': 'GetDoorMoveRot'
+    'body': 'GetDoorMoveRot(${1:doorid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'SetDoorMoveRot':
+    'prefix': 'SetDoorMoveRot'
+    'body': 'SetDoorMoveRot(${1:doorid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'GetDoorState':
+    'prefix': 'GetDoorState'
+    'body': 'GetDoorState(${1:doorid})'
+
+  'OnPlayerActivateDoor':
+    'prefix': 'OnPlayerActivateDoor'
+    'body': 'OnPlayerActivateDoor(${1:playerid}, ${2:doorid}, ${3:newstate})'
+
+  'OnDoorStateChange':
+    'prefix': 'OnDoorStateChange'
+    'body': 'OnDoorStateChange(${1:doorid}, ${2:doorstate})'

--- a/snippets/SIF.GEID.pwn.cson
+++ b/snippets/SIF.GEID.pwn.cson
@@ -1,0 +1,11 @@
+# SIF.GEID.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'mkgeid':
+    'prefix': 'mkgeid'
+    'body': 'mkgeid(${1:id}, ${2:result[]})'
+
+  'b64_encode':
+    'prefix': 'b64_encode'
+    'body': 'b64_encode(${1:data[]}, ${2:data_len}, ${3:result[]}, ${4:result_len})'

--- a/snippets/SIF.Inventory.pwn.cson
+++ b/snippets/SIF.Inventory.pwn.cson
@@ -1,0 +1,63 @@
+# SIF.Inventory.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'AddItemToInventory':
+    'prefix': 'AddItemToInventory'
+    'body': 'AddItemToInventory(${1:playerid}, ${2:itemid}, ${3:call = 1})'
+
+  'RemoveItemFromInventory':
+    'prefix': 'RemoveItemFromInventory'
+    'body': 'RemoveItemFromInventory(${1:playerid}, ${2:slotid}, ${3:call = 1})'
+
+  'GetInventorySlotItem':
+    'prefix': 'GetInventorySlotItem'
+    'body': 'GetInventorySlotItem(${1:playerid}, ${2:slotid})'
+
+  'IsInventorySlotUsed':
+    'prefix': 'IsInventorySlotUsed'
+    'body': 'IsInventorySlotUsed(${1:playerid}, ${2:slotid})'
+
+  'IsPlayerInventoryFull':
+    'prefix': 'IsPlayerInventoryFull'
+    'body': 'IsPlayerInventoryFull(${1:playerid})'
+
+  'WillItemTypeFitInInventory':
+    'prefix': 'WillItemTypeFitInInventory'
+    'body': 'WillItemTypeFitInInventory(${1:playerid}, ${2:ItemType:itemtype})'
+
+  'GetInventoryFreeSlots':
+    'prefix': 'GetInventoryFreeSlots'
+    'body': 'GetInventoryFreeSlots(${1:playerid})'
+
+  'GetItemPlayerInventory':
+    'prefix': 'GetItemPlayerInventory'
+    'body': 'GetItemPlayerInventory(${1:itemid})'
+
+  'GetItemPlayerInventorySlot':
+    'prefix': 'GetItemPlayerInventorySlot'
+    'body': 'GetItemPlayerInventorySlot(${1:itemid})'
+
+  'SetPlayerInventorySize':
+    'prefix': 'SetPlayerInventorySize'
+    'body': 'SetPlayerInventorySize(${1:playerid}, ${2:slots})'
+
+  'GetPlayerInventorySize':
+    'prefix': 'GetPlayerInventorySize'
+    'body': 'GetPlayerInventorySize(${1:playerid})'
+
+  'OnItemAddToInventory':
+    'prefix': 'OnItemAddToInventory'
+    'body': 'OnItemAddToInventory(${1:playerid}, ${2:itemid}, ${3:slot})'
+
+  'OnItemAddedToInventory':
+    'prefix': 'OnItemAddedToInventory'
+    'body': 'OnItemAddedToInventory(${1:playerid}, ${2:itemid}, ${3:slot})'
+
+  'OnItemRemoveFromInventory':
+    'prefix': 'OnItemRemoveFromInventory'
+    'body': 'OnItemRemoveFromInventory(${1:playerid}, ${2:itemid}, ${3:slot})'
+
+  'OnItemRemovedFromInventory':
+    'prefix': 'OnItemRemovedFromInventory'
+    'body': 'OnItemRemovedFromInventory(${1:playerid}, ${2:itemid}, ${3:slot})'

--- a/snippets/SIF.InventoryDialog.pwn.cson
+++ b/snippets/SIF.InventoryDialog.pwn.cson
@@ -1,0 +1,71 @@
+# SIF.InventoryDialog.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'DisplayPlayerInventory':
+    'prefix': 'DisplayPlayerInventory'
+    'body': 'DisplayPlayerInventory(${1:playerid})'
+
+  'ClosePlayerInventory':
+    'prefix': 'ClosePlayerInventory'
+    'body': 'ClosePlayerInventory(${1:playerid}, ${2:call = false})'
+
+  'GetPlayerSelectedInventorySlot':
+    'prefix': 'GetPlayerSelectedInventorySlot'
+    'body': 'GetPlayerSelectedInventorySlot(${1:playerid})'
+
+  'AddInventoryListItem':
+    'prefix': 'AddInventoryListItem'
+    'body': 'AddInventoryListItem(${1:playerid}, ${2:itemname[]})'
+
+  'AddInventoryOption':
+    'prefix': 'AddInventoryOption'
+    'body': 'AddInventoryOption(${1:playerid}, ${2:option[]})'
+
+  'GetInventoryListItems':
+    'prefix': 'GetInventoryListItems'
+    'body': 'GetInventoryListItems(${1:playerid})'
+
+  'GetInventoryOptions':
+    'prefix': 'GetInventoryOptions'
+    'body': 'GetInventoryOptions(${1:playerid})'
+
+  'GetInventoryListItemCount':
+    'prefix': 'GetInventoryListItemCount'
+    'body': 'GetInventoryListItemCount(${1:playerid})'
+
+  'GetInventoryOptionCount':
+    'prefix': 'GetInventoryOptionCount'
+    'body': 'GetInventoryOptionCount(${1:playerid})'
+
+  'IsPlayerViewingInventory':
+    'prefix': 'IsPlayerViewingInventory'
+    'body': 'IsPlayerViewingInventory(${1:playerid})'
+
+  'OnPlayerOpenInventory':
+    'prefix': 'OnPlayerOpenInventory'
+    'body': 'OnPlayerOpenInventory(${1:playerid})'
+
+  'OnPlayerCloseInventory':
+    'prefix': 'OnPlayerCloseInventory'
+    'body': 'OnPlayerCloseInventory(${1:playerid})'
+
+  'OnPlayerSelectExtraItem':
+    'prefix': 'OnPlayerSelectExtraItem'
+    'body': 'OnPlayerSelectExtraItem(${1:playerid}, ${2:item})'
+
+  'OnPlayerRemoveFromInventory':
+    'prefix': 'OnPlayerRemoveFromInventory'
+    'body': 'OnPlayerRemoveFromInventory(${1:playerid}, ${2:slotid})'
+
+  'OnPlayerRemovedFromInventory':
+    'prefix': 'OnPlayerRemovedFromInventory'
+    'body': 'OnPlayerRemovedFromInventory(${1:playerid}, ${2:slotid})'
+
+  'OnPlayerViewInventoryOpt':
+    'prefix': 'OnPlayerViewInventoryOpt'
+    'body': 'OnPlayerViewInventoryOpt(${1:playerid})'
+
+  'OnPlayerSelectInventoryOpt':
+    'prefix': 'OnPlayerSelectInventoryOpt'
+    'body': 'OnPlayerSelectInventoryOpt(${1:playerid}, ${2:option})'

--- a/snippets/SIF.InventoryKeys.pwn.cson
+++ b/snippets/SIF.InventoryKeys.pwn.cson
@@ -1,0 +1,11 @@
+# SIF.InventoryKeys.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'OnPlayerAddToInventory':
+    'prefix': 'OnPlayerAddToInventory'
+    'body': 'OnPlayerAddToInventory(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerAddedToInventory':
+    'prefix': 'OnPlayerAddedToInventory'
+    'body': 'OnPlayerAddedToInventory(${1:playerid}, ${2:itemid})'

--- a/snippets/SIF.Item.pwn.cson
+++ b/snippets/SIF.Item.pwn.cson
@@ -1,0 +1,287 @@
+# SIF.Item.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'CreateItem':
+    'prefix': 'CreateItem'
+    'body': 'CreateItem(${1:ItemType:type}, ${2:Float:x = 0.0}, ${3:Float:y = 0.0}, ${4:Float:z = 0.0}, ${5:Float:rx = 0.0}, ${6:Float:ry = 0.0}, ${7:Float:rz = 0.0}, ${8:world = 0}, ${9:interior = 0}, ${10:label = 1}, ${11:applyrotoffsets = 1}, ${12:virtual = 0}, ${13:geid[] = \"\"}, ${14:hitpoints = -1})'
+
+  'DestroyItem':
+    'prefix': 'DestroyItem'
+    'body': 'DestroyItem(${1:itemid}, ${2:indexid = -1}, ${3:worldindexid = -1})'
+
+  'DefineItemType':
+    'prefix': 'DefineItemType'
+    'body': 'DefineItemType(${1:name[]}, ${2:uname[]}, ${3:model}, ${4:size}, ${5:Float:rotx = 0.0}, ${6:Float:roty = 0.0}, ${7:Float:rotz = 0.0}, ${8:Float:modelz = 0.0}, ${9:Float:attx = 0.0}, ${10:Float:atty = 0.0}, ${11:Float:attz = 0.0}, ${12:Float:attrx = 0.0}, ${13:Float:attry = 0.0}, ${14:Float:attrz = 0.0}, ${15:bool:usecarryanim = false}, ${16:colour = -1}, ${17:boneid = 6}, ${18:longpickup = false}, ${19:Float:buttonz = FLOOR_OFFSET}, ${20:maxhitpoints = 5})'
+
+  'PlayerPickUpItem':
+    'prefix': 'PlayerPickUpItem'
+    'body': 'PlayerPickUpItem(${1:playerid}, ${2:itemid})'
+
+  'PlayerDropItem':
+    'prefix': 'PlayerDropItem'
+    'body': 'PlayerDropItem(${1:playerid})'
+
+  'PlayerGiveItem':
+    'prefix': 'PlayerGiveItem'
+    'body': 'PlayerGiveItem(${1:playerid}, ${2:targetid}, ${3:call = true})'
+
+  'PlayerUseItem':
+    'prefix': 'PlayerUseItem'
+    'body': 'PlayerUseItem(${1:playerid})'
+
+  'GiveWorldItemToPlayer':
+    'prefix': 'GiveWorldItemToPlayer'
+    'body': 'GiveWorldItemToPlayer(${1:playerid}, ${2:itemid}, ${3:call = 1})'
+
+  'RemoveCurrentItem':
+    'prefix': 'RemoveCurrentItem'
+    'body': 'RemoveCurrentItem(${1:playerid})'
+
+  'RemoveItemFromWorld':
+    'prefix': 'RemoveItemFromWorld'
+    'body': 'RemoveItemFromWorld(${1:itemid})'
+
+  'AllocNextItemID':
+    'prefix': 'AllocNextItemID'
+    'body': 'AllocNextItemID(${1:ItemType:type}, ${2:geid[] = \"\"})'
+
+  'CreateItem_ExplicitID':
+    'prefix': 'CreateItem_ExplicitID'
+    'body': 'CreateItem_ExplicitID(${1:itemid}, ${2:Float:x = 0.0}, ${3:Float:y = 0.0}, ${4:Float:z = 0.0}, ${5:Float:rx = 0.0}, ${6:Float:ry = 0.0}, ${7:Float:rz = 0.0}, ${8:world = 0}, ${9:interior = 0}, ${10:label = 1}, ${11:applyrotoffsets = 1}, ${12:virtual = 0}, ${13:hitpoints = -1})'
+
+  'IsValidItem':
+    'prefix': 'IsValidItem'
+    'body': 'IsValidItem(${1:itemid})'
+
+  'GetItemObjectID':
+    'prefix': 'GetItemObjectID'
+    'body': 'GetItemObjectID(${1:itemid})'
+
+  'GetItemButtonID':
+    'prefix': 'GetItemButtonID'
+    'body': 'GetItemButtonID(${1:itemid})'
+
+  'SetItemLabel':
+    'prefix': 'SetItemLabel'
+    'body': 'SetItemLabel(${1:itemid}, ${2:text[]}, ${3:colour = 0xFFFF00FF}, ${4:Float:range = 10.0})'
+
+  'GetItemTypeCount':
+    'prefix': 'GetItemTypeCount'
+    'body': 'GetItemTypeCount(${1:ItemType:itemtype})'
+
+  'GetItemType':
+    'prefix': 'GetItemType'
+    'body': 'GetItemType(${1:itemid})'
+
+  'GetItemPos':
+    'prefix': 'GetItemPos'
+    'body': 'GetItemPos(${1:itemid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'SetItemPos':
+    'prefix': 'SetItemPos'
+    'body': 'SetItemPos(${1:itemid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetItemRot':
+    'prefix': 'GetItemRot'
+    'body': 'GetItemRot(${1:itemid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'SetItemRot':
+    'prefix': 'SetItemRot'
+    'body': 'SetItemRot(${1:itemid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz}, ${5:bool:offsetfromdefaults = false})'
+
+  'SetItemWorld':
+    'prefix': 'SetItemWorld'
+    'body': 'SetItemWorld(${1:itemid}, ${2:world})'
+
+  'GetItemWorld':
+    'prefix': 'GetItemWorld'
+    'body': 'GetItemWorld(${1:itemid})'
+
+  'SetItemInterior':
+    'prefix': 'SetItemInterior'
+    'body': 'SetItemInterior(${1:itemid}, ${2:interior})'
+
+  'GetItemInterior':
+    'prefix': 'GetItemInterior'
+    'body': 'GetItemInterior(${1:itemid})'
+
+  'SetItemHitPoints':
+    'prefix': 'SetItemHitPoints'
+    'body': 'SetItemHitPoints(${1:itemid}, ${2:hitpoints})'
+
+  'GetItemHitPoints':
+    'prefix': 'GetItemHitPoints'
+    'body': 'GetItemHitPoints(${1:itemid})'
+
+  'SetItemExtraData':
+    'prefix': 'SetItemExtraData'
+    'body': 'SetItemExtraData(${1:itemid}, ${2:data})'
+
+  'GetItemExtraData':
+    'prefix': 'GetItemExtraData'
+    'body': 'GetItemExtraData(${1:itemid})'
+
+  'SetItemNameExtra':
+    'prefix': 'SetItemNameExtra'
+    'body': 'SetItemNameExtra(${1:itemid}, ${2:string[]})'
+
+  'GetItemNameExtra':
+    'prefix': 'GetItemNameExtra'
+    'body': 'GetItemNameExtra(${1:itemid}, ${2:string[]})'
+
+  'IsValidItemType':
+    'prefix': 'IsValidItemType'
+    'body': 'IsValidItemType(${1:ItemType:itemtype})'
+
+  'GetItemTypeName':
+    'prefix': 'GetItemTypeName'
+    'body': 'GetItemTypeName(${1:ItemType:itemtype}, ${2:string[]})'
+
+  'GetItemTypeUniqueName':
+    'prefix': 'GetItemTypeUniqueName'
+    'body': 'GetItemTypeUniqueName(${1:ItemType:itemtype}, ${2:string[]})'
+
+  'GetItemTypeFromUniqueName':
+    'prefix': 'GetItemTypeFromUniqueName'
+    'body': 'GetItemTypeFromUniqueName(${1:string[]}, ${2:bool:ignorecase = false})'
+
+  'GetItemTypeModel':
+    'prefix': 'GetItemTypeModel'
+    'body': 'GetItemTypeModel(${1:ItemType:itemtype})'
+
+  'GetItemTypeSize':
+    'prefix': 'GetItemTypeSize'
+    'body': 'GetItemTypeSize(${1:ItemType:itemtype})'
+
+  'IsItemTypeCarry':
+    'prefix': 'IsItemTypeCarry'
+    'body': 'IsItemTypeCarry(${1:ItemType:itemtype})'
+
+  'GetItemTypeColour':
+    'prefix': 'GetItemTypeColour'
+    'body': 'GetItemTypeColour(${1:ItemType:itemtype})'
+
+  'GetItemTypeBone':
+    'prefix': 'GetItemTypeBone'
+    'body': 'GetItemTypeBone(${1:ItemType:itemtype})'
+
+  'IsItemDestroying':
+    'prefix': 'IsItemDestroying'
+    'body': 'IsItemDestroying(${1:itemid})'
+
+  'GetItemHolder':
+    'prefix': 'GetItemHolder'
+    'body': 'GetItemHolder(${1:itemid})'
+
+  'GetPlayerItem':
+    'prefix': 'GetPlayerItem'
+    'body': 'GetPlayerItem(${1:playerid})'
+
+  'IsItemInWorld':
+    'prefix': 'IsItemInWorld'
+    'body': 'IsItemInWorld(${1:itemid})'
+
+  'GetItemFromButtonID':
+    'prefix': 'GetItemFromButtonID'
+    'body': 'GetItemFromButtonID(${1:buttonid})'
+
+  'GetItemName':
+    'prefix': 'GetItemName'
+    'body': 'GetItemName(${1:itemid}, ${2:string[]})'
+
+  'GetPlayerInteractingItem':
+    'prefix': 'GetPlayerInteractingItem'
+    'body': 'GetPlayerInteractingItem(${1:playerid})'
+
+  'GetPlayerNearbyItems':
+    'prefix': 'GetPlayerNearbyItems'
+    'body': 'GetPlayerNearbyItems(${1:playerid}, ${2:list[]})'
+
+  'GetNextItemID':
+    'prefix': 'GetNextItemID'
+    'body': 'GetNextItemID()'
+
+  'GetItemsInRange':
+    'prefix': 'GetItemsInRange'
+    'body': 'GetItemsInRange(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:Float:range = 300.0}, ${5:items[]}, ${6:maxitems = sizeof(items})'
+
+  'OnItemTypeDefined':
+    'prefix': 'OnItemTypeDefined'
+    'body': 'OnItemTypeDefined(${1:uname[]})'
+
+  'OnItemCreate':
+    'prefix': 'OnItemCreate'
+    'body': 'OnItemCreate(${1:itemid})'
+
+  'OnItemCreated':
+    'prefix': 'OnItemCreated'
+    'body': 'OnItemCreated(${1:itemid})'
+
+  'OnItemDestroy':
+    'prefix': 'OnItemDestroy'
+    'body': 'OnItemDestroy(${1:itemid})'
+
+  'OnItemDestroyed':
+    'prefix': 'OnItemDestroyed'
+    'body': 'OnItemDestroyed(${1:itemid})'
+
+  'OnItemCreateInWorld':
+    'prefix': 'OnItemCreateInWorld'
+    'body': 'OnItemCreateInWorld(${1:itemid})'
+
+  'OnItemRemoveFromWorld':
+    'prefix': 'OnItemRemoveFromWorld'
+    'body': 'OnItemRemoveFromWorld(${1:itemid})'
+
+  'OnPlayerUseItem':
+    'prefix': 'OnPlayerUseItem'
+    'body': 'OnPlayerUseItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerUseItemWithItem':
+    'prefix': 'OnPlayerUseItemWithItem'
+    'body': 'OnPlayerUseItemWithItem(${1:playerid}, ${2:itemid}, ${3:withitemid})'
+
+  'OnPlayerUseItemWithButton':
+    'prefix': 'OnPlayerUseItemWithButton'
+    'body': 'OnPlayerUseItemWithButton(${1:playerid}, ${2:buttonid}, ${3:itemid})'
+
+  'OnPlayerRelButtonWithItem':
+    'prefix': 'OnPlayerRelButtonWithItem'
+    'body': 'OnPlayerRelButtonWithItem(${1:playerid}, ${2:buttonid}, ${3:itemid})'
+
+  'OnPlayerPickUpItem':
+    'prefix': 'OnPlayerPickUpItem'
+    'body': 'OnPlayerPickUpItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerPickedUpItem':
+    'prefix': 'OnPlayerPickedUpItem'
+    'body': 'OnPlayerPickedUpItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerGetItem':
+    'prefix': 'OnPlayerGetItem'
+    'body': 'OnPlayerGetItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerDropItem':
+    'prefix': 'OnPlayerDropItem'
+    'body': 'OnPlayerDropItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerDroppedItem':
+    'prefix': 'OnPlayerDroppedItem'
+    'body': 'OnPlayerDroppedItem(${1:playerid}, ${2:itemid})'
+
+  'OnPlayerGiveItem':
+    'prefix': 'OnPlayerGiveItem'
+    'body': 'OnPlayerGiveItem(${1:playerid}, ${2:targetid}, ${3:itemid})'
+
+  'OnPlayerGivenItem':
+    'prefix': 'OnPlayerGivenItem'
+    'body': 'OnPlayerGivenItem(${1:playerid}, ${2:targetid}, ${3:itemid})'
+
+  'OnItemRemovedFromPlayer':
+    'prefix': 'OnItemRemovedFromPlayer'
+    'body': 'OnItemRemovedFromPlayer(${1:playerid}, ${2:itemid})'
+
+  'OnItemNameRender':
+    'prefix': 'OnItemNameRender'
+    'body': 'OnItemNameRender(${1:itemid}, ${2:ItemType:itemtype})'

--- a/snippets/SIF.ItemArrayData.pwn.cson
+++ b/snippets/SIF.ItemArrayData.pwn.cson
@@ -1,0 +1,71 @@
+# SIF.ItemArrayData.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'SetItemExtraData(%0,%1)':
+    'prefix': 'SetItemExtraData(%0,%1)'
+    'body': 'SetItemExtraData(${1:0},${2:1})'
+
+  'GetItemExtraData(%0)':
+    'prefix': 'GetItemExtraData(%0)'
+    'body': 'GetItemExtraData(${1:0})'
+
+  'SetItemTypeMaxArrayData':
+    'prefix': 'SetItemTypeMaxArrayData'
+    'body': 'SetItemTypeMaxArrayData(${1:ItemType:itemtype}, ${2:size}, ${3:bool:protect = false})'
+
+  'GetItemTypeArrayDataSize':
+    'prefix': 'GetItemTypeArrayDataSize'
+    'body': 'GetItemTypeArrayDataSize(${1:ItemType:itemtype})'
+
+  'SetItemArrayData':
+    'prefix': 'SetItemArrayData'
+    'body': 'SetItemArrayData(${1:itemid}, ${2:data[]}, ${3:length}, ${4:call = 1}, ${5:bool:force = false})'
+
+  'GetItemArrayData':
+    'prefix': 'GetItemArrayData'
+    'body': 'GetItemArrayData(${1:itemid}, ${2:data[]})'
+
+  'SetItemArrayDataAtCell':
+    'prefix': 'SetItemArrayDataAtCell'
+    'body': 'SetItemArrayDataAtCell(${1:itemid}, ${2:data}, ${3:cell}, ${4:autoadjustsize = 0}, ${5:call = 1}, ${6:bool:force = false})'
+
+  'GetItemArrayDataAtCell':
+    'prefix': 'GetItemArrayDataAtCell'
+    'body': 'GetItemArrayDataAtCell(${1:itemid}, ${2:cell})'
+
+  'SetItemArrayDataSize':
+    'prefix': 'SetItemArrayDataSize'
+    'body': 'SetItemArrayDataSize(${1:itemid}, ${2:size}, ${3:bool:force = false})'
+
+  'GetItemArrayDataSize':
+    'prefix': 'GetItemArrayDataSize'
+    'body': 'GetItemArrayDataSize(${1:itemid})'
+
+  'GetItemTypeArrayDataMax':
+    'prefix': 'GetItemTypeArrayDataMax'
+    'body': 'GetItemTypeArrayDataMax(${1:ItemType:itemtype})'
+
+  'AppendItemArray':
+    'prefix': 'AppendItemArray'
+    'body': 'AppendItemArray(${1:itemid}, ${2:data[]}, ${3:length})'
+
+  'AppendItemArrayCell':
+    'prefix': 'AppendItemArrayCell'
+    'body': 'AppendItemArrayCell(${1:itemid}, ${2:data})'
+
+  'SetItemArrayDataLength':
+    'prefix': 'SetItemArrayDataLength'
+    'body': 'SetItemArrayDataLength(${1:itemid}, ${2:length}, ${3:bool:force = false})'
+
+  'RemoveItemArrayData':
+    'prefix': 'RemoveItemArrayData'
+    'body': 'RemoveItemArrayData(${1:itemid})'
+
+  'SetItemNoResetArrayData':
+    'prefix': 'SetItemNoResetArrayData'
+    'body': 'SetItemNoResetArrayData(${1:itemid}, ${2:bool:toggle})'
+
+  'OnItemArrayDataChanged':
+    'prefix': 'OnItemArrayDataChanged'
+    'body': 'OnItemArrayDataChanged(${1:itemid})'

--- a/snippets/SIF.ItemList.pwn.cson
+++ b/snippets/SIF.ItemList.pwn.cson
@@ -1,0 +1,71 @@
+# SIF.ItemList.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'ITM_LST_OF_ITEMS(%0)':
+    'prefix': 'ITM_LST_OF_ITEMS(%0)'
+    'body': 'ITM_LST_OF_ITEMS(${1:0})'
+
+  'CreateItemList':
+    'prefix': 'CreateItemList'
+    'body': 'CreateItemList(${1:items[]}, ${2:maxitems = sizeof(items})'
+
+  'ExtractItemList':
+    'prefix': 'ExtractItemList'
+    'body': 'ExtractItemList(${1:list[]}, ${2:length = sizeof(list})'
+
+  'DestroyItemList':
+    'prefix': 'DestroyItemList'
+    'body': 'DestroyItemList(${1:itemlist})'
+
+  'GetItemList':
+    'prefix': 'GetItemList'
+    'body': 'GetItemList(${1:itemlist}, ${2:output[]})'
+
+  'GetItemListSize':
+    'prefix': 'GetItemListSize'
+    'body': 'GetItemListSize(${1:itemlist})'
+
+  'GetItemListElement':
+    'prefix': 'GetItemListElement'
+    'body': 'GetItemListElement(${1:itemlist}, ${2:index})'
+
+  'GetItemListItemCount':
+    'prefix': 'GetItemListItemCount'
+    'body': 'GetItemListItemCount(${1:itemlist})'
+
+  'GetItemListItem':
+    'prefix': 'GetItemListItem'
+    'body': 'GetItemListItem(${1:itemlist}, ${2:index})'
+
+  'GetItemListItemPos':
+    'prefix': 'GetItemListItemPos'
+    'body': 'GetItemListItemPos(${1:itemlist}, ${2:index}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'GetItemListItemRot':
+    'prefix': 'GetItemListItemRot'
+    'body': 'GetItemListItemRot(${1:itemlist}, ${2:index}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z})'
+
+  'GetItemListItemWorld':
+    'prefix': 'GetItemListItemWorld'
+    'body': 'GetItemListItemWorld(${1:itemlist}, ${2:index})'
+
+  'GetItemListItemInterior':
+    'prefix': 'GetItemListItemInterior'
+    'body': 'GetItemListItemInterior(${1:itemlist}, ${2:index})'
+
+  'GetItemListItemArrayData':
+    'prefix': 'GetItemListItemArrayData'
+    'body': 'GetItemListItemArrayData(${1:itemlist}, ${2:index}, ${3:output[]})'
+
+  'GetItemListItemArrayDataSize':
+    'prefix': 'GetItemListItemArrayDataSize'
+    'body': 'GetItemListItemArrayDataSize(${1:itemlist}, ${2:index})'
+
+  'CreateItemFromListItem':
+    'prefix': 'CreateItemFromListItem'
+    'body': 'CreateItemFromListItem(${1:itemlist}, ${2:index})'
+
+  'SetItemArrayDataFromListItem':
+    'prefix': 'SetItemArrayDataFromListItem'
+    'body': 'SetItemArrayDataFromListItem(${1:itemid}, ${2:itemlist}, ${3:index})'

--- a/snippets/SIF.ItemSerializer.pwn.cson
+++ b/snippets/SIF.ItemSerializer.pwn.cson
@@ -1,0 +1,59 @@
+# SIF.ItemSerializer.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'SerialiseItems':
+    'prefix': 'SerialiseItems'
+    'body': 'SerialiseItems(${1:items[]}, ${2:maxitems = sizeof(items})'
+
+  'DeserialiseItems':
+    'prefix': 'DeserialiseItems'
+    'body': 'DeserialiseItems(${1:list[]}, ${2:length = sizeof(list})'
+
+  'ClearSerializer':
+    'prefix': 'ClearSerializer'
+    'body': 'ClearSerializer()'
+
+  'GetSerialisedSize':
+    'prefix': 'GetSerialisedSize'
+    'body': 'GetSerialisedSize()'
+
+  'GetStoredItemCount':
+    'prefix': 'GetStoredItemCount'
+    'body': 'GetStoredItemCount()'
+
+  'GetStoredItemType':
+    'prefix': 'GetStoredItemType'
+    'body': 'GetStoredItemType(${1:index})'
+
+  'GetStoredItemPos':
+    'prefix': 'GetStoredItemPos'
+    'body': 'GetStoredItemPos(${1:index}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetStoredItemRot':
+    'prefix': 'GetStoredItemRot'
+    'body': 'GetStoredItemRot(${1:index}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetStoredItemWorld':
+    'prefix': 'GetStoredItemWorld'
+    'body': 'GetStoredItemWorld(${1:index})'
+
+  'GetStoredItemInterior':
+    'prefix': 'GetStoredItemInterior'
+    'body': 'GetStoredItemInterior(${1:index})'
+
+  'GetStoredItemArrayData':
+    'prefix': 'GetStoredItemArrayData'
+    'body': 'GetStoredItemArrayData(${1:index}, ${2:output[]})'
+
+  'GetStoredItemArrayDataSize':
+    'prefix': 'GetStoredItemArrayDataSize'
+    'body': 'GetStoredItemArrayDataSize(${1:index})'
+
+  'CreateItemFromStored':
+    'prefix': 'CreateItemFromStored'
+    'body': 'CreateItemFromStored(${1:index})'
+
+  'SetItemArrayDataFromStored':
+    'prefix': 'SetItemArrayDataFromStored'
+    'body': 'SetItemArrayDataFromStored(${1:itemid}, ${2:index})'

--- a/snippets/SIF.MultiButton.pwn.cson
+++ b/snippets/SIF.MultiButton.pwn.cson
@@ -1,0 +1,15 @@
+# SIF.MultiButton.pwn snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'CreateMultiButtonTrigger':
+    'prefix': 'CreateMultiButtonTrigger'
+    'body': 'CreateMultiButtonTrigger(${1:type}, ${2:timewindow}, ${3:list[]}, ${4:count = sizeof(list})'
+
+  'DestroyMultiButtonTrigger':
+    'prefix': 'DestroyMultiButtonTrigger'
+    'body': 'DestroyMultiButtonTrigger(${1:triggerid})'
+
+  'OnMultiButtonTrigger':
+    'prefix': 'OnMultiButtonTrigger'
+    'body': 'OnMultiButtonTrigger(${1:triggerid}, ${2:success})'

--- a/snippets/als.cson
+++ b/snippets/als.cson
@@ -1,0 +1,18 @@
+# ALS snippets (completions) for Atom
+# Originally created by Renato "Hii" Garcia
+'.source.pwn, .source.inc':
+  'ALS Callback':
+    'prefix': 'ALS'
+    'body': 'public ${1:Callback}($3)\n{\n\t#if defined ${2:prefix}_${1:Callback}\n\t\treturn ${2:prefix}_${1:Callback}($3);\n\t#else\n\t\treturn 1;\n\t#endif\n}\n#if defined _ALS_${1:Callback}\n\t#undef ${1:Callback}\n#else\n\t#define _ALS_${1:Callback}\n#endif\n#define ${1:Callback} ${2:prefix}_${1:Callback}\n#if defined ${2:prefix}_${1:Callback}\n\tforward ${2:prefix}_${1:Callback}($3);\n#endif'
+
+  'ALS Function':
+    'prefix': 'ALS '
+    'body': 'stock ${1:Prefix}_${2:Function}(${3:args})\n{\n\t${4}\n\treturn ${2}(${3});\n}\n#if defined _ALS_${2}\n\t#undef ${2}\n#else\n\t#define _ALS_${2}\n#endif\n#define ${2} ${1}_${2}'
+
+  'ALS Script Init':
+    'prefix': 'ALS  '
+    'body': '#if defined FILTERSCRIPT\n\tpublic OnFilterScriptInit()\n#else\n\tpublic OnGameModeInit()\n#endif\n{\n\t${2:// CODE HERE}\n\n\t#if defined FILTERSCRIPT\n\t\t#if defined ${1:Prefix}_OnFilterScriptInit\n\t\t\treturn ${1:Prefix}_OnFilterScriptInit();\n\t\t#else\n\t\t\treturn 1;\n\t\t#endif\n\t#else\n\t\t#if defined ${1:Prefix}_OnGameModeInit\n\t\t\treturn ${1:Prefix}_OnGameModeInit();\n\t\t#else\n\t\t\treturn 1;\n\t\t#endif\n\t#endif\n}\n\n#if defined FILTERSCRIPT\n\t#if defined _ALS_OnFilterScriptInit\n\t\t#undef OnFilterScriptInit\n\t#else\n\t\t#define _ALS_OnFilterScriptInit\n\t#endif\n\n\t#define OnFilterScriptInit ${1:Prefix}_OnFilterScriptInit\n\t#if defined ${1:Prefix}_OnFilterScriptInit\n\t\tforward ${1:Prefix}_OnFilterScriptInit();\n\t#endif\n#else\n\t#if defined _ALS_OnGameModeInit\n\t\t#undef OnGameModeInit\n\t#else\n\t\t#define _ALS_OnGameModeInit\n\t#endif\n\n\t#define OnGameModeInit ${1:Prefix}_OnGameModeInit\n\t#if defined ${1:Prefix}_OnGameModeInit\n\t\tforward ${1:Prefix}_OnGameModeInit();\n\t#endif\n#endif'
+
+  'ALS Script Exit':
+    'prefix': 'ALS   '
+    'body': '#if defined FILTERSCRIPT\n\tpublic OnFilterScriptExit()\n#else\n\tpublic OnGameModeExit()\n#endif\n{\n\t${2:// CODE HERE}\n\n\t#if defined FILTERSCRIPT\n\t\t#if defined ${1:Prefix}_OnFilterScriptExit\n\t\t\treturn ${1:Prefix}_OnFilterScriptExit();\n\t\t#else\n\t\t\treturn 1;\n\t\t#endif\n\t#else\n\t\t#if defined ${1:Prefix}_OnGameModeExit\n\t\t\treturn ${1:Prefix}_OnGameModeExit();\n\t\t#else\n\t\t\treturn 1;\n\t\t#endif\n\t#endif\n}\n\n#if defined FILTERSCRIPT\n\t#if defined _ALS_OnFilterScriptExit\n\t\t#undef OnFilterScriptExit\n\t#else\n\t\t#define _ALS_OnFilterScriptExit\n\t#endif\n\n\t#define OnFilterScriptExit ${1:Prefix}_OnFilterScriptExit\n\t#if defined ${1:Prefix}_OnFilterScriptExit\n\t\tforward ${1:Prefix}_OnFilterScriptExit();\n\t#endif\n#else\n\t#if defined _ALS_OnGameModeExit\n\t\t#undef OnGameModeExit\n\t#else\n\t\t#define _ALS_OnGameModeExit\n\t#endif\n\n\t#define OnGameModeExit ${1:Prefix}_OnGameModeExit\n\t#if defined ${1:Prefix}_OnGameModeExit\n\t\tforward ${1:Prefix}_OnGameModeExit();\n\t#endif\n#endif'

--- a/snippets/crashdetect.cson
+++ b/snippets/crashdetect.cson
@@ -1,0 +1,27 @@
+# crashdetect snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'PrintAmxBacktrace':
+    'prefix': 'PrintAmxBacktrace'
+    'body': 'PrintAmxBacktrace()'
+
+  'PrintNativeBacktrace':
+    'prefix': 'PrintNativeBacktrace'
+    'body': 'PrintNativeBacktrace()'
+
+  'GetAmxBacktrace':
+    'prefix': 'GetAmxBacktrace'
+    'body': 'GetAmxBacktrace(${1:string[]}, ${2:size = sizeof(string})'
+
+  'GetNativeBacktrace':
+    'prefix': 'GetNativeBacktrace'
+    'body': 'GetNativeBacktrace(${1:string[]}, ${2:size = sizeof(string})'
+
+  'OnRuntimeError':
+    'prefix': 'OnRuntimeError'
+    'body': 'OnRuntimeError(${1:code}, ${2:bool:suppress})'
+
+  'IsCrashDetectPresent':
+    'prefix': 'IsCrashDetectPresent'
+    'body': 'IsCrashDetectPresent()'

--- a/snippets/file.cson
+++ b/snippets/file.cson
@@ -1,0 +1,59 @@
+# Atom Snippets from Sublime Text Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia.
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'fopen':
+    'prefix': 'fopen'
+    'body': 'fopen(${1:const name[]}, ${2:filemode: mode = io_readwrite})'
+
+  'fclose':
+    'prefix': 'fclose'
+    'body': 'fclose(${1:File: handle})'
+
+  'ftemp':
+    'prefix': 'ftemp'
+    'body': 'ftemp()'
+
+  'fremove':
+    'prefix': 'fremove'
+    'body': 'fremove(${1:const name[]})'
+
+  'fwrite':
+    'prefix': 'fwrite'
+    'body': 'fwrite(${1:File: handle}, ${2:const string[]})'
+
+  'fread':
+    'prefix': 'fread'
+    'body': 'fread(${1:File: handle}, ${2:string[]}, ${3:size = sizeof string}, ${4:bool: pack = false})'
+
+  'fputchar':
+    'prefix': 'fputchar'
+    'body': 'fputchar(${1:File: handle}, ${2:value}, ${3:bool: utf8 = true})'
+
+  'fgetchar':
+    'prefix': 'fgetchar'
+    'body': 'fgetchar(${1:File: handle}, ${2:value}, ${3:bool: utf8 = true})'
+
+  'fblockwrite':
+    'prefix': 'fblockwrite'
+    'body': 'fblockwrite(${1:File: handle}, ${2:const buffer[]}, ${3:size = sizeof buffer})'
+
+  'fblockread':
+    'prefix': 'fblockread'
+    'body': 'fblockread(${1:File: handle}, ${2:buffer[]}, ${3:size = sizeof buffer})'
+
+  'fseek':
+    'prefix': 'fseek'
+    'body': 'fseek(${1:File: handle}, ${2:position = 0}, ${3:seek_whence: whence = seek_start})'
+
+  'flength':
+    'prefix': 'flength'
+    'body': 'flength(${1:File: handle})'
+
+  'fexist':
+    'prefix': 'fexist'
+    'body': 'fexist(${1:const pattern[]})'
+
+  'fmatch':
+    'prefix': 'fmatch'
+    'body': 'fmatch(${1:name[]}, ${2:const pattern[]}, ${3:index = 0}, ${4:size = sizeof name})'

--- a/snippets/gvar.cson
+++ b/snippets/gvar.cson
@@ -1,0 +1,43 @@
+# GVar snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'SetGVarInt':
+    'prefix': 'SetGVarInt'
+    'body': 'SetGVarInt(${1:const name[]}, ${2:value}, ${3:id = 0})'
+
+  'GetGVarInt':
+    'prefix': 'GetGVarInt'
+    'body': 'GetGVarInt(${1:const name[]}, ${2:id = 0})'
+
+  'SetGVarString':
+    'prefix': 'SetGVarString'
+    'body': 'SetGVarString(${1:const name[]}, ${2:const value[]}, ${3:id = 0})'
+
+  'GetGVarString':
+    'prefix': 'GetGVarString'
+    'body': 'GetGVarString(${1:const name[]}, ${2:dest[]}, ${3:maxlength = sizeof dest}, ${4:id = 0})'
+
+  'SetGVarFloat':
+    'prefix': 'SetGVarFloat'
+    'body': 'SetGVarFloat(${1:const name[]}, ${2:Float:value}, ${3:id = 0})'
+
+  'GetGVarFloat':
+    'prefix': 'GetGVarFloat'
+    'body': 'GetGVarFloat(${1:const name[]}, ${2:id = 0})'
+
+  'DeleteGVar':
+    'prefix': 'DeleteGVar'
+    'body': 'DeleteGVar(${1:const name[]}, ${2:id = 0})'
+
+  'GetGVarsUpperIndex':
+    'prefix': 'GetGVarsUpperIndex'
+    'body': 'GetGVarsUpperIndex(${1:id = 0})'
+
+  'GetGVarNameAtIndex':
+    'prefix': 'GetGVarNameAtIndex'
+    'body': 'GetGVarNameAtIndex(${1:index}, ${2:dest[]}, ${3:maxlength = sizeof dest}, ${4:id = 0})'
+
+  'GetGVarType':
+    'prefix': 'GetGVarType'
+    'body': 'GetGVarType(${1:const name[]}, ${2:id = 0})'

--- a/snippets/irc.cson
+++ b/snippets/irc.cson
@@ -1,0 +1,203 @@
+# IRC Plugin Atom Snippets from Sublime Text Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia.
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'IRC_Connect':
+    'prefix': 'IRC_Connect'
+    'body': 'IRC_Connect(${1:const server[]}, ${2:port}, ${3:const nickname[]}, ${4:const realname[]}, ${5:const username[]}, ${6:bool:ssl = false}, ${7:const localip[] = \"\"}, ${8:const serverpassword[] = \"\"})'
+
+  'IRC_Quit':
+    'prefix': 'IRC_Quit'
+    'body': 'IRC_Quit(${1:botid}, ${2:const message[] = \"\"})'
+
+  'IRC_JoinChannel':
+    'prefix': 'IRC_JoinChannel'
+    'body': 'IRC_JoinChannel(${1:botid}, ${2:const channel[]}, ${3:const key[] = \"\"})'
+
+  'IRC_PartChannel':
+    'prefix': 'IRC_PartChannel'
+    'body': 'IRC_PartChannel(${1:botid}, ${2:const channel[]}, ${3:const message[] = \"\"})'
+
+  'IRC_ChangeNick':
+    'prefix': 'IRC_ChangeNick'
+    'body': 'IRC_ChangeNick(${1:botid}, ${2:const nick[]})'
+
+  'IRC_SetMode':
+    'prefix': 'IRC_SetMode'
+    'body': 'IRC_SetMode(${1:botid}, ${2:const target[]}, ${3:const mode[]})'
+
+  'IRC_Say':
+    'prefix': 'IRC_Say'
+    'body': 'IRC_Say(${1:botid}, ${2:const target[]}, ${3:const message[]})'
+
+  'IRC_Notice':
+    'prefix': 'IRC_Notice'
+    'body': 'IRC_Notice(${1:botid}, ${2:const target[]}, ${3:const message[]})'
+
+  'IRC_IsUserOnChannel':
+    'prefix': 'IRC_IsUserOnChannel'
+    'body': 'IRC_IsUserOnChannel(${1:botid}, ${2:const channel[]}, ${3:const user[]})'
+
+  'IRC_InviteUser':
+    'prefix': 'IRC_InviteUser'
+    'body': 'IRC_InviteUser(${1:botid}, ${2:const channel[]}, ${3:const user[]})'
+
+  'IRC_KickUser':
+    'prefix': 'IRC_KickUser'
+    'body': 'IRC_KickUser(${1:botid}, ${2:const channel[]}, ${3:const user[]}, ${4:const message[] = \"\"})'
+
+  'IRC_GetUserChannelMode':
+    'prefix': 'IRC_GetUserChannelMode'
+    'body': 'IRC_GetUserChannelMode(${1:botid}, ${2:const channel[]}, ${3:const user[]}, ${4:dest[]})'
+
+  'IRC_GetChannelUserList':
+    'prefix': 'IRC_GetChannelUserList'
+    'body': 'IRC_GetChannelUserList(${1:botid}, ${2:const channel[]}, ${3:dest[]}, ${4:maxlength = sizeof dest})'
+
+  'IRC_SetChannelTopic':
+    'prefix': 'IRC_SetChannelTopic'
+    'body': 'IRC_SetChannelTopic(${1:botid}, ${2:const channel[]}, ${3:const topic[]})'
+
+  'IRC_RequestCTCP':
+    'prefix': 'IRC_RequestCTCP'
+    'body': 'IRC_RequestCTCP(${1:botid}, ${2:const user[]}, ${3:const message[]})'
+
+  'IRC_ReplyCTCP':
+    'prefix': 'IRC_ReplyCTCP'
+    'body': 'IRC_ReplyCTCP(${1:botid}, ${2:const user[]}, ${3:const message[]})'
+
+  'IRC_SendRaw':
+    'prefix': 'IRC_SendRaw'
+    'body': 'IRC_SendRaw(${1:botid}, ${2:const message[]})'
+
+  'IRC_CreateGroup':
+    'prefix': 'IRC_CreateGroup'
+    'body': 'IRC_CreateGroup()'
+
+  'IRC_DestroyGroup':
+    'prefix': 'IRC_DestroyGroup'
+    'body': 'IRC_DestroyGroup(${1:groupid})'
+
+  'IRC_AddToGroup':
+    'prefix': 'IRC_AddToGroup'
+    'body': 'IRC_AddToGroup(${1:groupid}, ${2:botid})'
+
+  'IRC_RemoveFromGroup':
+    'prefix': 'IRC_RemoveFromGroup'
+    'body': 'IRC_RemoveFromGroup(${1:groupid}, ${2:botid})'
+
+  'IRC_GroupSay':
+    'prefix': 'IRC_GroupSay'
+    'body': 'IRC_GroupSay(${1:groupid}, ${2:const target[]}, ${3:const message[]})'
+
+  'IRC_GroupNotice':
+    'prefix': 'IRC_GroupNotice'
+    'body': 'IRC_GroupNotice(${1:groupid}, ${2:const target[]}, ${3:const message[]})'
+
+  'IRC_SetIntData':
+    'prefix': 'IRC_SetIntData'
+    'body': 'IRC_SetIntData(${1:botid}, ${2:data}, ${3:value})'
+
+  'IRC_OnConnect':
+    'prefix': 'IRC_OnConnect'
+    'body': 'IRC_OnConnect(${1:botid}, ${2:ip[]}, ${3:port})'
+
+  'IRC_OnDisconnect':
+    'prefix': 'IRC_OnDisconnect'
+    'body': 'IRC_OnDisconnect(${1:botid}, ${2:ip[]}, ${3:port}, ${4:reason[]})'
+
+  'IRC_OnConnectAttempt':
+    'prefix': 'IRC_OnConnectAttempt'
+    'body': 'IRC_OnConnectAttempt(${1:botid}, ${2:ip[]}, ${3:port})'
+
+  'IRC_OnConnectAttemptFail':
+    'prefix': 'IRC_OnConnectAttemptFail'
+    'body': 'IRC_OnConnectAttemptFail(${1:botid}, ${2:ip[]}, ${3:port}, ${4:reason[]})'
+
+  'IRC_OnJoinChannel':
+    'prefix': 'IRC_OnJoinChannel'
+    'body': 'IRC_OnJoinChannel(${1:botid}, ${2:channel[]})'
+
+  'IRC_OnLeaveChannel':
+    'prefix': 'IRC_OnLeaveChannel'
+    'body': 'IRC_OnLeaveChannel(${1:botid}, ${2:channel[]}, ${3:message[]})'
+
+  'IRC_OnInvitedToChannel':
+    'prefix': 'IRC_OnInvitedToChannel'
+    'body': 'IRC_OnInvitedToChannel(${1:botid}, ${2:channel[]}, ${3:invitinguser[]}, ${4:invitinghost[]})'
+
+  'IRC_OnKickedFromChannel':
+    'prefix': 'IRC_OnKickedFromChannel'
+    'body': 'IRC_OnKickedFromChannel(${1:botid}, ${2:channel[]}, ${3:oppeduser[]}, ${4:oppedhost[]}, ${5:message[]})'
+
+  'IRC_OnUserDisconnect':
+    'prefix': 'IRC_OnUserDisconnect'
+    'body': 'IRC_OnUserDisconnect(${1:botid}, ${2:user[]}, ${3:host[]}, ${4:message[]})'
+
+  'IRC_OnUserJoinChannel':
+    'prefix': 'IRC_OnUserJoinChannel'
+    'body': 'IRC_OnUserJoinChannel(${1:botid}, ${2:channel[]}, ${3:user[]}, ${4:host[]})'
+
+  'IRC_OnUserLeaveChannel':
+    'prefix': 'IRC_OnUserLeaveChannel'
+    'body': 'IRC_OnUserLeaveChannel(${1:botid}, ${2:channel[]}, ${3:user[]}, ${4:host[]}, ${5:message[]})'
+
+  'IRC_OnUserKickedFromChannel':
+    'prefix': 'IRC_OnUserKickedFromChannel'
+    'body': 'IRC_OnUserKickedFromChannel(${1:botid}, ${2:channel[]}, ${3:kickeduser[]}, ${4:oppeduser[]}, ${5:oppedhost[]}, ${6:message[]})'
+
+  'IRC_OnUserNickChange':
+    'prefix': 'IRC_OnUserNickChange'
+    'body': 'IRC_OnUserNickChange(${1:botid}, ${2:oldnick[]}, ${3:newnick[]}, ${4:host[]})'
+
+  'IRC_OnUserSetChannelMode':
+    'prefix': 'IRC_OnUserSetChannelMode'
+    'body': 'IRC_OnUserSetChannelMode(${1:botid}, ${2:channel[]}, ${3:user[]}, ${4:host[]}, ${5:mode[]})'
+
+  'IRC_OnUserSetChannelTopic':
+    'prefix': 'IRC_OnUserSetChannelTopic'
+    'body': 'IRC_OnUserSetChannelTopic(${1:botid}, ${2:channel[]}, ${3:user[]}, ${4:host[]}, ${5:topic[]})'
+
+  'IRC_OnUserSay':
+    'prefix': 'IRC_OnUserSay'
+    'body': 'IRC_OnUserSay(${1:botid}, ${2:recipient[]}, ${3:user[]}, ${4:host[]}, ${5:message[]})'
+
+  'IRC_OnUserNotice':
+    'prefix': 'IRC_OnUserNotice'
+    'body': 'IRC_OnUserNotice(${1:botid}, ${2:recipient[]}, ${3:user[]}, ${4:host[]}, ${5:message[]})'
+
+  'IRC_OnUserRequestCTCP':
+    'prefix': 'IRC_OnUserRequestCTCP'
+    'body': 'IRC_OnUserRequestCTCP(${1:botid}, ${2:user[]}, ${3:host[]}, ${4:message[]})'
+
+  'IRC_OnUserReplyCTCP':
+    'prefix': 'IRC_OnUserReplyCTCP'
+    'body': 'IRC_OnUserReplyCTCP(${1:botid}, ${2:user[]}, ${3:host[]}, ${4:message[]})'
+
+  'IRC_OnReceiveNumeric':
+    'prefix': 'IRC_OnReceiveNumeric'
+    'body': 'IRC_OnReceiveNumeric(${1:botid}, ${2:numeric}, ${3:message[]})'
+
+  'IRC_OnReceiveRaw':
+    'prefix': 'IRC_OnReceiveRaw'
+    'body': 'IRC_OnReceiveRaw(${1:botid}, ${2:message[]})'
+
+  'IRC_IsVoice':
+    'prefix': 'IRC_IsVoice'
+    'body': 'IRC_IsVoice(${1:botid}, ${2:channel[]}, ${3:user[]})'
+
+  'IRC_IsHalfop':
+    'prefix': 'IRC_IsHalfop'
+    'body': 'IRC_IsHalfop(${1:botid}, ${2:channel[]}, ${3:user[]})'
+
+  'IRC_IsOp':
+    'prefix': 'IRC_IsOp'
+    'body': 'IRC_IsOp(${1:botid}, ${2:channel[]}, ${3:user[]})'
+
+  'IRC_IsAdmin':
+    'prefix': 'IRC_IsAdmin'
+    'body': 'IRC_IsAdmin(${1:botid}, ${2:channel[]}, ${3:user[]})'
+
+  'IRC_IsOwner':
+    'prefix': 'IRC_IsOwner'
+    'body': 'IRC_IsOwner(${1:botid}, ${2:channel[]}, ${3:user[]})'

--- a/snippets/language-pawn.cson
+++ b/snippets/language-pawn.cson
@@ -14,7 +14,7 @@
     'body': 'for(new ${1:i} = 0; ${1:i} < ${2:count}; ${1:i}${3:++})\n{\n\t${4:/* code */}\n}'
   'include guard':
     'prefix': 'incgrd'
-    'body': '#if !defined _INC_${1:SYMBOL}\n\t#endinput\n#endif\n#define _INC_$1'
+    'body': '#if defined _INC_${1:SYMBOL}\n\t#endinput\n#endif\n#define _INC_$1'
   'do while loop':
     'prefix': 'do'
     'body': 'do\n{\n\t${0:/* code */}\n} while(${1:/* condition */});'

--- a/snippets/socket.cson
+++ b/snippets/socket.cson
@@ -1,0 +1,119 @@
+# Socket Plugin Atom Snippets from Sublime Text Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia.
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'socket_create':
+    'prefix': 'socket_create'
+    'body': 'socket_create(${1:pType:TCP})'
+
+  'socket_bind':
+    'prefix': 'socket_bind'
+    'body': 'socket_bind(${1:Socket:id}, ${2:ip[]})'
+
+  'socket_connect':
+    'prefix': 'socket_connect'
+    'body': 'socket_connect(${1:Socket:id}, ${2:host[]}, ${3:port})'
+
+  'socket_listen':
+    'prefix': 'socket_listen'
+    'body': 'socket_listen(${1:Socket:id}, ${2:port})'
+
+  'socket_stop_listen':
+    'prefix': 'socket_stop_listen'
+    'body': 'socket_stop_listen(${1:Socket:id})'
+
+  'socket_destroy':
+    'prefix': 'socket_destroy'
+    'body': 'socket_destroy(${1:Socket:id})'
+
+  'socket_send':
+    'prefix': 'socket_send'
+    'body': 'socket_send(${1:Socket:id}, ${2:data[]}, ${3:len})'
+
+  'socket_sendto':
+    'prefix': 'socket_sendto'
+    'body': 'socket_sendto(${1:Socket:id}, ${2:const ip[]}, ${3:port}, ${4:data[]}, ${5:len})'
+
+  'socket_send_array':
+    'prefix': 'socket_send_array'
+    'body': 'socket_send_array(${1:Socket:id}, ${2:data[]}, ${3:size=sizeof(data})'
+
+  'is_socket_valid':
+    'prefix': 'is_socket_valid'
+    'body': 'is_socket_valid(${1:Socket:id})'
+
+  'socket_set_max_connections':
+    'prefix': 'socket_set_max_connections'
+    'body': 'socket_set_max_connections(${1:Socket:id}, ${2:max_remote_clients})'
+
+  'socket_close_remote_client':
+    'prefix': 'socket_close_remote_client'
+    'body': 'socket_close_remote_client(${1:Socket:id}, ${2:remote_clientid})'
+
+  'socket_sendto_remote_client':
+    'prefix': 'socket_sendto_remote_client'
+    'body': 'socket_sendto_remote_client(${1:Socket:id}, ${2:remote_clientid}, ${3:data[]})'
+
+  'socket_remote_client_connected':
+    'prefix': 'socket_remote_client_connected'
+    'body': 'socket_remote_client_connected(${1:Socket:id}, ${2:remote_clientid})'
+
+  'get_remote_client_ip':
+    'prefix': 'get_remote_client_ip'
+    'body': 'get_remote_client_ip(${1:Socket:id}, ${2:remote_clientid}, ${3:ip[]})'
+
+  'ssl_init':
+    'prefix': 'ssl_init'
+    'body': 'ssl_init()'
+
+  'ssl_create_context':
+    'prefix': 'ssl_create_context'
+    'body': 'ssl_create_context(${1:Socket:id}, ${2:method})'
+
+  'ssl_connect':
+    'prefix': 'ssl_connect'
+    'body': 'ssl_connect(${1:Socket:id})'
+
+  'ssl_load_cert_into_context':
+    'prefix': 'ssl_load_cert_into_context'
+    'body': 'ssl_load_cert_into_context(${1:Socket:id}, ${2:const certificate[]}, ${3:const private_key[]})'
+
+  'ssl_shutdown':
+    'prefix': 'ssl_shutdown'
+    'body': 'ssl_shutdown(${1:Socket:id})'
+
+  'ssl_get_peer_certificate':
+    'prefix': 'ssl_get_peer_certificate'
+    'body': 'ssl_get_peer_certificate(${1:Socket:id}, ${2:method}, ${3:subject[]}, ${4:issuer[]}, ${5:remote_clientid = 0xFFFF})'
+
+  'ssl_set_accept_timeout':
+    'prefix': 'ssl_set_accept_timeout'
+    'body': 'ssl_set_accept_timeout(${1:Socket:id}, ${2:interval})'
+
+  'ssl_set_mode':
+    'prefix': 'ssl_set_mode'
+    'body': 'ssl_set_mode(${1:Socket:id}, ${2:mode})'
+
+  'onUDPReceiveData':
+    'prefix': 'onUDPReceiveData'
+    'body': 'onUDPReceiveData(${1:Socket:id}, ${2:data[]}, ${3:data_len}, ${4:remote_client_ip[]}, ${5:remote_client_port})'
+
+  'onSocketAnswer':
+    'prefix': 'onSocketAnswer'
+    'body': 'onSocketAnswer(${1:Socket:id}, ${2:data[]}, ${3:data_len})'
+
+  'onSocketClose':
+    'prefix': 'onSocketClose'
+    'body': 'onSocketClose(${1:Socket:id})'
+
+  'onSocketReceiveData':
+    'prefix': 'onSocketReceiveData'
+    'body': 'onSocketReceiveData(${1:Socket:id}, ${2:remote_clientid}, ${3:data[]}, ${4:data_len})'
+
+  'onSocketRemoteConnect':
+    'prefix': 'onSocketRemoteConnect'
+    'body': 'onSocketRemoteConnect(${1:Socket:id}, ${2:remote_client[]}, ${3:remote_clientid})'
+
+  'onSocketRemoteDisconnect':
+    'prefix': 'onSocketRemoteDisconnect'
+    'body': 'onSocketRemoteDisconnect(${1:Socket:id}, ${2:remote_clientid})'

--- a/snippets/sscanf2.cson
+++ b/snippets/sscanf2.cson
@@ -1,0 +1,11 @@
+# sscanf2 snippets for Atom converted from Sublime Completions converted from https://github.com/Southclaw/pawn-sublime-language
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'sscanf':
+    'prefix': 'sscanf'
+    'body': 'sscanf(${1:const data[]}, ${2:const format[]}, ${3:...})'
+
+  'unformat':
+    'prefix': 'unformat'
+    'body': 'unformat(${1:const data[]}, ${2:const format[]}, ${3:...})'

--- a/snippets/streamer.cson
+++ b/snippets/streamer.cson
@@ -1,0 +1,659 @@
+# Incognito's Streamer snippets for Atom converted from Sublime Completions
+# Converter created by Renato "Hii" Garcia
+# Repo: https://github.com/Renato-Garcia/sublime-completions-to-atom-snippets
+'.source.pwn, .source.inc':
+  'Streamer_GetTickRate':
+    'prefix': 'Streamer_GetTickRate'
+    'body': 'Streamer_GetTickRate()'
+
+  'Streamer_SetTickRate':
+    'prefix': 'Streamer_SetTickRate'
+    'body': 'Streamer_SetTickRate(${1:rate})'
+
+  'Streamer_GetMaxItems':
+    'prefix': 'Streamer_GetMaxItems'
+    'body': 'Streamer_GetMaxItems(${1:type})'
+
+  'Streamer_SetMaxItems':
+    'prefix': 'Streamer_SetMaxItems'
+    'body': 'Streamer_SetMaxItems(${1:type}, ${2:items})'
+
+  'Streamer_GetVisibleItems':
+    'prefix': 'Streamer_GetVisibleItems'
+    'body': 'Streamer_GetVisibleItems(${1:type}, ${2:playerid = -1})'
+
+  'Streamer_SetVisibleItems':
+    'prefix': 'Streamer_SetVisibleItems'
+    'body': 'Streamer_SetVisibleItems(${1:type}, ${2:items}, ${3:playerid = -1})'
+
+  'Streamer_GetRadiusMultiplier':
+    'prefix': 'Streamer_GetRadiusMultiplier'
+    'body': 'Streamer_GetRadiusMultiplier(${1:type}, ${2:Float:multiplier}, ${3:playerid = -1})'
+
+  'Streamer_SetRadiusMultiplier':
+    'prefix': 'Streamer_SetRadiusMultiplier'
+    'body': 'Streamer_SetRadiusMultiplier(${1:type}, ${2:Float:multiplier}, ${3:playerid = -1})'
+
+  'Streamer_GetTypePriority':
+    'prefix': 'Streamer_GetTypePriority'
+    'body': 'Streamer_GetTypePriority(${1:types[]}, ${2:maxtypes = sizeof types})'
+
+  'Streamer_SetTypePriority':
+    'prefix': 'Streamer_SetTypePriority'
+    'body': 'Streamer_SetTypePriority(${1:const types[]}, ${2:maxtypes = sizeof types})'
+
+  'Streamer_GetCellDistance':
+    'prefix': 'Streamer_GetCellDistance'
+    'body': 'Streamer_GetCellDistance(${1:Float:distance})'
+
+  'Streamer_SetCellDistance':
+    'prefix': 'Streamer_SetCellDistance'
+    'body': 'Streamer_SetCellDistance(${1:Float:distance})'
+
+  'Streamer_GetCellSize':
+    'prefix': 'Streamer_GetCellSize'
+    'body': 'Streamer_GetCellSize(${1:Float:size})'
+
+  'Streamer_SetCellSize':
+    'prefix': 'Streamer_SetCellSize'
+    'body': 'Streamer_SetCellSize(${1:Float:size})'
+
+  'Streamer_ToggleErrorCallback':
+    'prefix': 'Streamer_ToggleErrorCallback'
+    'body': 'Streamer_ToggleErrorCallback(${1:toggle})'
+
+  'Streamer_IsToggleErrorCallback':
+    'prefix': 'Streamer_IsToggleErrorCallback'
+    'body': 'Streamer_IsToggleErrorCallback()'
+
+  'Streamer_ProcessActiveItems':
+    'prefix': 'Streamer_ProcessActiveItems'
+    'body': 'Streamer_ProcessActiveItems()'
+
+  'Streamer_ToggleIdleUpdate':
+    'prefix': 'Streamer_ToggleIdleUpdate'
+    'body': 'Streamer_ToggleIdleUpdate(${1:playerid}, ${2:toggle})'
+
+  'Streamer_IsToggleIdleUpdate':
+    'prefix': 'Streamer_IsToggleIdleUpdate'
+    'body': 'Streamer_IsToggleIdleUpdate(${1:playerid})'
+
+  'Streamer_ToggleCameraUpdate':
+    'prefix': 'Streamer_ToggleCameraUpdate'
+    'body': 'Streamer_ToggleCameraUpdate(${1:playerid}, ${2:toggle})'
+
+  'Streamer_IsToggleCameraUpdate':
+    'prefix': 'Streamer_IsToggleCameraUpdate'
+    'body': 'Streamer_IsToggleCameraUpdate(${1:playerid})'
+
+  'Streamer_ToggleItemUpdate':
+    'prefix': 'Streamer_ToggleItemUpdate'
+    'body': 'Streamer_ToggleItemUpdate(${1:playerid}, ${2:type}, ${3:toggle})'
+
+  'Streamer_IsToggleItemUpdate':
+    'prefix': 'Streamer_IsToggleItemUpdate'
+    'body': 'Streamer_IsToggleItemUpdate(${1:playerid}, ${2:type})'
+
+  'Streamer_Update':
+    'prefix': 'Streamer_Update'
+    'body': 'Streamer_Update(${1:playerid}, ${2:type = -1})'
+
+  'Streamer_UpdateEx':
+    'prefix': 'Streamer_UpdateEx'
+    'body': 'Streamer_UpdateEx(${1:playerid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:worldid = -1}, ${6:interiorid = -1}, ${7:type = -1})'
+
+  'Streamer_GetFloatData':
+    'prefix': 'Streamer_GetFloatData'
+    'body': 'Streamer_GetFloatData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:Float:result})'
+
+  'Streamer_SetFloatData':
+    'prefix': 'Streamer_SetFloatData'
+    'body': 'Streamer_SetFloatData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:Float:value})'
+
+  'Streamer_GetIntData':
+    'prefix': 'Streamer_GetIntData'
+    'body': 'Streamer_GetIntData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data})'
+
+  'Streamer_SetIntData':
+    'prefix': 'Streamer_SetIntData'
+    'body': 'Streamer_SetIntData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:value})'
+
+  'Streamer_GetArrayData':
+    'prefix': 'Streamer_GetArrayData'
+    'body': 'Streamer_GetArrayData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:dest[]}, ${5:maxdest = sizeof dest})'
+
+  'Streamer_SetArrayData':
+    'prefix': 'Streamer_SetArrayData'
+    'body': 'Streamer_SetArrayData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:const src[]}, ${5:maxsrc = sizeof src})'
+
+  'Streamer_IsInArrayData':
+    'prefix': 'Streamer_IsInArrayData'
+    'body': 'Streamer_IsInArrayData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:value})'
+
+  'Streamer_AppendArrayData':
+    'prefix': 'Streamer_AppendArrayData'
+    'body': 'Streamer_AppendArrayData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:value})'
+
+  'Streamer_RemoveArrayData':
+    'prefix': 'Streamer_RemoveArrayData'
+    'body': 'Streamer_RemoveArrayData(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:data}, ${4:value})'
+
+  'Streamer_GetUpperBound':
+    'prefix': 'Streamer_GetUpperBound'
+    'body': 'Streamer_GetUpperBound(${1:type})'
+
+  'Streamer_GetDistanceToItem':
+    'prefix': 'Streamer_GetDistanceToItem'
+    'body': 'Streamer_GetDistanceToItem(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:type}, ${5:STREAMER_ALL_TAGS id}, ${6:Float:distance}, ${7:dimensions = 3})'
+
+  'Streamer_ToggleStaticItem':
+    'prefix': 'Streamer_ToggleStaticItem'
+    'body': 'Streamer_ToggleStaticItem(${1:type}, ${2:STREAMER_ALL_TAGS id}, ${3:toggle})'
+
+  'Streamer_IsToggleStaticItem':
+    'prefix': 'Streamer_IsToggleStaticItem'
+    'body': 'Streamer_IsToggleStaticItem(${1:type}, ${2:STREAMER_ALL_TAGS id})'
+
+  'Streamer_GetItemInternalID':
+    'prefix': 'Streamer_GetItemInternalID'
+    'body': 'Streamer_GetItemInternalID(${1:playerid}, ${2:type}, ${3:STREAMER_ALL_TAGS streamerid})'
+
+  'Streamer_GetItemStreamerID':
+    'prefix': 'Streamer_GetItemStreamerID'
+    'body': 'Streamer_GetItemStreamerID(${1:playerid}, ${2:type}, ${3:internalid})'
+
+  'Streamer_IsItemVisible':
+    'prefix': 'Streamer_IsItemVisible'
+    'body': 'Streamer_IsItemVisible(${1:playerid}, ${2:type}, ${3:STREAMER_ALL_TAGS id})'
+
+  'Streamer_DestroyAllVisibleItems':
+    'prefix': 'Streamer_DestroyAllVisibleItems'
+    'body': 'Streamer_DestroyAllVisibleItems(${1:playerid}, ${2:type}, ${3:serverwide = 1})'
+
+  'Streamer_CountVisibleItems':
+    'prefix': 'Streamer_CountVisibleItems'
+    'body': 'Streamer_CountVisibleItems(${1:playerid}, ${2:type}, ${3:serverwide = 1})'
+
+  'Streamer_DestroyAllItems':
+    'prefix': 'Streamer_DestroyAllItems'
+    'body': 'Streamer_DestroyAllItems(${1:type}, ${2:serverwide = 1})'
+
+  'Streamer_CountItems':
+    'prefix': 'Streamer_CountItems'
+    'body': 'Streamer_CountItems(${1:type}, ${2:serverwide = 1})'
+
+  'CreateDynamicObject':
+    'prefix': 'CreateDynamicObject'
+    'body': 'CreateDynamicObject(${1:modelid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:Float:rx}, ${6:Float:ry}, ${7:Float:rz}, ${8:worldid = -1}, ${9:interiorid = -1}, ${10:playerid = -1}, ${11:Float:streamdistance = STREAMER_OBJECT_SD}, ${12:Float:drawdistance = STREAMER_OBJECT_DD}, ${13:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamicObject':
+    'prefix': 'DestroyDynamicObject'
+    'body': 'DestroyDynamicObject(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'IsValidDynamicObject':
+    'prefix': 'IsValidDynamicObject'
+    'body': 'IsValidDynamicObject(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'SetDynamicObjectPos':
+    'prefix': 'SetDynamicObjectPos'
+    'body': 'SetDynamicObjectPos(${1:STREAMER_TAG_OBJECT objectid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'GetDynamicObjectPos':
+    'prefix': 'GetDynamicObjectPos'
+    'body': 'GetDynamicObjectPos(${1:STREAMER_TAG_OBJECT objectid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'SetDynamicObjectRot':
+    'prefix': 'SetDynamicObjectRot'
+    'body': 'SetDynamicObjectRot(${1:STREAMER_TAG_OBJECT objectid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'GetDynamicObjectRot':
+    'prefix': 'GetDynamicObjectRot'
+    'body': 'GetDynamicObjectRot(${1:STREAMER_TAG_OBJECT objectid}, ${2:Float:rx}, ${3:Float:ry}, ${4:Float:rz})'
+
+  'SetDynamicObjectNoCameraCol':
+    'prefix': 'SetDynamicObjectNoCameraCol'
+    'body': 'SetDynamicObjectNoCameraCol(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'GetDynamicObjectNoCameraCol':
+    'prefix': 'GetDynamicObjectNoCameraCol'
+    'body': 'GetDynamicObjectNoCameraCol(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'MoveDynamicObject':
+    'prefix': 'MoveDynamicObject'
+    'body': 'MoveDynamicObject(${1:STREAMER_TAG_OBJECT objectid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:Float:speed}, ${6:Float:rx = -1000.0}, ${7:Float:ry = -1000.0}, ${8:Float:rz = -1000.0})'
+
+  'StopDynamicObject':
+    'prefix': 'StopDynamicObject'
+    'body': 'StopDynamicObject(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'IsDynamicObjectMoving':
+    'prefix': 'IsDynamicObjectMoving'
+    'body': 'IsDynamicObjectMoving(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'AttachCameraToDynamicObject':
+    'prefix': 'AttachCameraToDynamicObject'
+    'body': 'AttachCameraToDynamicObject(${1:playerid}, ${2:STREAMER_TAG_OBJECT objectid})'
+
+  'AttachDynamicObjectToObject':
+    'prefix': 'AttachDynamicObjectToObject'
+    'body': 'AttachDynamicObjectToObject(${1:STREAMER_TAG_OBJECT objectid}, ${2:attachtoid}, ${3:Float:offsetx}, ${4:Float:offsety}, ${5:Float:offsetz}, ${6:Float:rx}, ${7:Float:ry}, ${8:Float:rz}, ${9:syncrotation = 1})'
+
+  'AttachDynamicObjectToPlayer':
+    'prefix': 'AttachDynamicObjectToPlayer'
+    'body': 'AttachDynamicObjectToPlayer(${1:STREAMER_TAG_OBJECT objectid}, ${2:playerid}, ${3:Float:offsetx}, ${4:Float:offsety}, ${5:Float:offsetz}, ${6:Float:rx}, ${7:Float:ry}, ${8:Float:rz})'
+
+  'AttachDynamicObjectToVehicle':
+    'prefix': 'AttachDynamicObjectToVehicle'
+    'body': 'AttachDynamicObjectToVehicle(${1:STREAMER_TAG_OBJECT objectid}, ${2:vehicleid}, ${3:Float:offsetx}, ${4:Float:offsety}, ${5:Float:offsetz}, ${6:Float:rx}, ${7:Float:ry}, ${8:Float:rz})'
+
+  'EditDynamicObject':
+    'prefix': 'EditDynamicObject'
+    'body': 'EditDynamicObject(${1:playerid}, ${2:STREAMER_TAG_OBJECT objectid})'
+
+  'IsDynamicObjectMaterialUsed':
+    'prefix': 'IsDynamicObjectMaterialUsed'
+    'body': 'IsDynamicObjectMaterialUsed(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex})'
+
+  'GetDynamicObjectMaterial':
+    'prefix': 'GetDynamicObjectMaterial'
+    'body': 'GetDynamicObjectMaterial(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex}, ${3:modelid}, ${4:txdname[]}, ${5:texturename[]}, ${6:materialcolor}, ${7:maxtxdname = sizeof txdname}, ${8:maxtexturename = sizeof texturename})'
+
+  'SetDynamicObjectMaterial':
+    'prefix': 'SetDynamicObjectMaterial'
+    'body': 'SetDynamicObjectMaterial(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex}, ${3:modelid}, ${4:const txdname[]}, ${5:const texturename[]}, ${6:materialcolor = 0})'
+
+  'IsDynamicObjectMaterialTextUsed':
+    'prefix': 'IsDynamicObjectMaterialTextUsed'
+    'body': 'IsDynamicObjectMaterialTextUsed(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex})'
+
+  'GetDynamicObjectMaterialText':
+    'prefix': 'GetDynamicObjectMaterialText'
+    'body': 'GetDynamicObjectMaterialText(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex}, ${3:text[]}, ${4:materialsize}, ${5:fontface[]}, ${6:fontsize}, ${7:bold}, ${8:fontcolor}, ${9:backcolor}, ${10:textalignment}, ${11:maxtext = sizeof text}, ${12:maxfontface = sizeof fontface})'
+
+  'SetDynamicObjectMaterialText':
+    'prefix': 'SetDynamicObjectMaterialText'
+    'body': 'SetDynamicObjectMaterialText(${1:STREAMER_TAG_OBJECT objectid}, ${2:materialindex}, ${3:const text[]}, ${4:materialsize = OBJECT_MATERIAL_SIZE_256x128}, ${5:const fontface[] = \"Arial\"}, ${6:fontsize = 24}, ${7:bold = 1}, ${8:fontcolor = 0xFFFFFFFF}, ${9:backcolor = 0}, ${10:textalignment = 0})'
+
+  'CreateDynamicPickup':
+    'prefix': 'CreateDynamicPickup'
+    'body': 'CreateDynamicPickup(${1:modelid}, ${2:type}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z}, ${6:worldid = -1}, ${7:interiorid = -1}, ${8:playerid = -1}, ${9:Float:streamdistance = STREAMER_PICKUP_SD}, ${10:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamicPickup':
+    'prefix': 'DestroyDynamicPickup'
+    'body': 'DestroyDynamicPickup(${1:STREAMER_TAG_PICKUP pickupid})'
+
+  'IsValidDynamicPickup':
+    'prefix': 'IsValidDynamicPickup'
+    'body': 'IsValidDynamicPickup(${1:STREAMER_TAG_PICKUP pickupid})'
+
+  'CreateDynamicCP':
+    'prefix': 'CreateDynamicCP'
+    'body': 'CreateDynamicCP(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:Float:size}, ${5:worldid = -1}, ${6:interiorid = -1}, ${7:playerid = -1}, ${8:Float:streamdistance = STREAMER_CP_SD}, ${9:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamicCP':
+    'prefix': 'DestroyDynamicCP'
+    'body': 'DestroyDynamicCP(${1:STREAMER_TAG_CP checkpointid})'
+
+  'IsValidDynamicCP':
+    'prefix': 'IsValidDynamicCP'
+    'body': 'IsValidDynamicCP(${1:STREAMER_TAG_CP checkpointid})'
+
+  'TogglePlayerDynamicCP':
+    'prefix': 'TogglePlayerDynamicCP'
+    'body': 'TogglePlayerDynamicCP(${1:playerid}, ${2:STREAMER_TAG_CP checkpointid}, ${3:toggle})'
+
+  'TogglePlayerAllDynamicCPs':
+    'prefix': 'TogglePlayerAllDynamicCPs'
+    'body': 'TogglePlayerAllDynamicCPs(${1:playerid}, ${2:toggle})'
+
+  'IsPlayerInDynamicCP':
+    'prefix': 'IsPlayerInDynamicCP'
+    'body': 'IsPlayerInDynamicCP(${1:playerid}, ${2:STREAMER_TAG_CP checkpointid})'
+
+  'GetPlayerVisibleDynamicCP':
+    'prefix': 'GetPlayerVisibleDynamicCP'
+    'body': 'GetPlayerVisibleDynamicCP(${1:playerid})'
+
+  'CreateDynamicRaceCP':
+    'prefix': 'CreateDynamicRaceCP'
+    'body': 'CreateDynamicRaceCP(${1:type}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:Float:nextx}, ${6:Float:nexty}, ${7:Float:nextz}, ${8:Float:size}, ${9:worldid = -1}, ${10:interiorid = -1}, ${11:playerid = -1}, ${12:Float:streamdistance = STREAMER_RACE_CP_SD}, ${13:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamicRaceCP':
+    'prefix': 'DestroyDynamicRaceCP'
+    'body': 'DestroyDynamicRaceCP(${1:STREAMER_TAG_RACE_CP checkpointid})'
+
+  'IsValidDynamicRaceCP':
+    'prefix': 'IsValidDynamicRaceCP'
+    'body': 'IsValidDynamicRaceCP(${1:STREAMER_TAG_RACE_CP checkpointid})'
+
+  'TogglePlayerDynamicRaceCP':
+    'prefix': 'TogglePlayerDynamicRaceCP'
+    'body': 'TogglePlayerDynamicRaceCP(${1:playerid}, ${2:STREAMER_TAG_RACE_CP checkpointid}, ${3:toggle})'
+
+  'TogglePlayerAllDynamicRaceCPs':
+    'prefix': 'TogglePlayerAllDynamicRaceCPs'
+    'body': 'TogglePlayerAllDynamicRaceCPs(${1:playerid}, ${2:toggle})'
+
+  'IsPlayerInDynamicRaceCP':
+    'prefix': 'IsPlayerInDynamicRaceCP'
+    'body': 'IsPlayerInDynamicRaceCP(${1:playerid}, ${2:STREAMER_TAG_RACE_CP checkpointid})'
+
+  'GetPlayerVisibleDynamicRaceCP':
+    'prefix': 'GetPlayerVisibleDynamicRaceCP'
+    'body': 'GetPlayerVisibleDynamicRaceCP(${1:playerid})'
+
+  'CreateDynamicMapIcon':
+    'prefix': 'CreateDynamicMapIcon'
+    'body': 'CreateDynamicMapIcon(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:type}, ${5:color}, ${6:worldid = -1}, ${7:interiorid = -1}, ${8:playerid = -1}, ${9:Float:streamdistance = STREAMER_MAP_ICON_SD}, ${10:style = MAPICON_LOCAL}, ${11:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamicMapIcon':
+    'prefix': 'DestroyDynamicMapIcon'
+    'body': 'DestroyDynamicMapIcon(${1:STREAMER_TAG_MAP_ICON iconid})'
+
+  'IsValidDynamicMapIcon':
+    'prefix': 'IsValidDynamicMapIcon'
+    'body': 'IsValidDynamicMapIcon(${1:STREAMER_TAG_MAP_ICON iconid})'
+
+  'CreateDynamic3DTextLabel':
+    'prefix': 'CreateDynamic3DTextLabel'
+    'body': 'CreateDynamic3DTextLabel(${1:const text[]}, ${2:color}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z}, ${6:Float:drawdistance}, ${7:attachedplayer = INVALID_PLAYER_ID}, ${8:attachedvehicle = INVALID_VEHICLE_ID}, ${9:testlos = 0}, ${10:worldid = -1}, ${11:interiorid = -1}, ${12:playerid = -1}, ${13:Float:streamdistance = STREAMER_3D_TEXT_LABEL_SD}, ${14:STREAMER_TAG_AREA areaid = STREAMER_TAG_AREA -1})'
+
+  'DestroyDynamic3DTextLabel':
+    'prefix': 'DestroyDynamic3DTextLabel'
+    'body': 'DestroyDynamic3DTextLabel(${1:STREAMER_TAG_3D_TEXT_LABEL id})'
+
+  'IsValidDynamic3DTextLabel':
+    'prefix': 'IsValidDynamic3DTextLabel'
+    'body': 'IsValidDynamic3DTextLabel(${1:STREAMER_TAG_3D_TEXT_LABEL id})'
+
+  'GetDynamic3DTextLabelText':
+    'prefix': 'GetDynamic3DTextLabelText'
+    'body': 'GetDynamic3DTextLabelText(${1:STREAMER_TAG_3D_TEXT_LABEL id}, ${2:text[]}, ${3:maxtext = sizeof text})'
+
+  'UpdateDynamic3DTextLabelText':
+    'prefix': 'UpdateDynamic3DTextLabelText'
+    'body': 'UpdateDynamic3DTextLabelText(${1:STREAMER_TAG_3D_TEXT_LABEL id}, ${2:color}, ${3:const text[]})'
+
+  'CreateDynamicCircle':
+    'prefix': 'CreateDynamicCircle'
+    'body': 'CreateDynamicCircle(${1:Float:x}, ${2:Float:y}, ${3:Float:size}, ${4:worldid = -1}, ${5:interiorid = -1}, ${6:playerid = -1})'
+
+  'CreateDynamicCylinder':
+    'prefix': 'CreateDynamicCylinder'
+    'body': 'CreateDynamicCylinder(${1:Float:x}, ${2:Float:y}, ${3:Float:minz}, ${4:Float:maxz}, ${5:Float:size}, ${6:worldid = -1}, ${7:interiorid = -1}, ${8:playerid = -1})'
+
+  'CreateDynamicSphere':
+    'prefix': 'CreateDynamicSphere'
+    'body': 'CreateDynamicSphere(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:Float:size}, ${5:worldid = -1}, ${6:interiorid = -1}, ${7:playerid = -1})'
+
+  'CreateDynamicRectangle':
+    'prefix': 'CreateDynamicRectangle'
+    'body': 'CreateDynamicRectangle(${1:Float:minx}, ${2:Float:miny}, ${3:Float:maxx}, ${4:Float:maxy}, ${5:worldid = -1}, ${6:interiorid = -1}, ${7:playerid = -1})'
+
+  'CreateDynamicCuboid':
+    'prefix': 'CreateDynamicCuboid'
+    'body': 'CreateDynamicCuboid(${1:Float:minx}, ${2:Float:miny}, ${3:Float:minz}, ${4:Float:maxx}, ${5:Float:maxy}, ${6:Float:maxz}, ${7:worldid = -1}, ${8:interiorid = -1}, ${9:playerid = -1})'
+
+  'CreateDynamicCube':
+    'prefix': 'CreateDynamicCube'
+    'body': 'CreateDynamicCube(${1:Float:minx}, ${2:Float:miny}, ${3:Float:minz}, ${4:Float:maxx}, ${5:Float:maxy}, ${6:Float:maxz}, ${7:worldid = -1}, ${8:interiorid = -1}, ${9:playerid = -1})'
+
+  'CreateDynamicPolygon':
+    'prefix': 'CreateDynamicPolygon'
+    'body': 'CreateDynamicPolygon(${1:Float:points[]}, ${2:Float:minz = -FLOAT_INFINITY}, ${3:Float:maxz = FLOAT_INFINITY}, ${4:maxpoints = sizeof points}, ${5:worldid = -1}, ${6:interiorid = -1}, ${7:playerid = -1})'
+
+  'DestroyDynamicArea':
+    'prefix': 'DestroyDynamicArea'
+    'body': 'DestroyDynamicArea(${1:STREAMER_TAG_AREA areaid})'
+
+  'IsValidDynamicArea':
+    'prefix': 'IsValidDynamicArea'
+    'body': 'IsValidDynamicArea(${1:STREAMER_TAG_AREA areaid})'
+
+  'GetDynamicPolygonPoints':
+    'prefix': 'GetDynamicPolygonPoints'
+    'body': 'GetDynamicPolygonPoints(${1:STREAMER_TAG_AREA areaid}, ${2:Float:points[]}, ${3:maxpoints = sizeof points})'
+
+  'GetDynamicPolygonNumberPoints':
+    'prefix': 'GetDynamicPolygonNumberPoints'
+    'body': 'GetDynamicPolygonNumberPoints(${1:STREAMER_TAG_AREA areaid})'
+
+  'TogglePlayerDynamicArea':
+    'prefix': 'TogglePlayerDynamicArea'
+    'body': 'TogglePlayerDynamicArea(${1:playerid}, ${2:STREAMER_TAG_AREA areaid}, ${3:toggle})'
+
+  'TogglePlayerAllDynamicAreas':
+    'prefix': 'TogglePlayerAllDynamicAreas'
+    'body': 'TogglePlayerAllDynamicAreas(${1:playerid}, ${2:toggle})'
+
+  'IsPlayerInDynamicArea':
+    'prefix': 'IsPlayerInDynamicArea'
+    'body': 'IsPlayerInDynamicArea(${1:playerid}, ${2:STREAMER_TAG_AREA areaid}, ${3:recheck = 0})'
+
+  'IsPlayerInAnyDynamicArea':
+    'prefix': 'IsPlayerInAnyDynamicArea'
+    'body': 'IsPlayerInAnyDynamicArea(${1:playerid}, ${2:recheck = 0})'
+
+  'IsAnyPlayerInDynamicArea':
+    'prefix': 'IsAnyPlayerInDynamicArea'
+    'body': 'IsAnyPlayerInDynamicArea(${1:STREAMER_TAG_AREA areaid}, ${2:recheck = 0})'
+
+  'IsAnyPlayerInAnyDynamicArea':
+    'prefix': 'IsAnyPlayerInAnyDynamicArea'
+    'body': 'IsAnyPlayerInAnyDynamicArea(${1:recheck = 0})'
+
+  'GetPlayerDynamicAreas':
+    'prefix': 'GetPlayerDynamicAreas'
+    'body': 'GetPlayerDynamicAreas(${1:playerid}, ${2:STREAMER_TAG_AREA areas[]}, ${3:maxareas = sizeof areas})'
+
+  'GetPlayerNumberDynamicAreas':
+    'prefix': 'GetPlayerNumberDynamicAreas'
+    'body': 'GetPlayerNumberDynamicAreas(${1:playerid})'
+
+  'IsPointInDynamicArea':
+    'prefix': 'IsPointInDynamicArea'
+    'body': 'IsPointInDynamicArea(${1:STREAMER_TAG_AREA areaid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z})'
+
+  'IsPointInAnyDynamicArea':
+    'prefix': 'IsPointInAnyDynamicArea'
+    'body': 'IsPointInAnyDynamicArea(${1:Float:x}, ${2:Float:y}, ${3:Float:z})'
+
+  'GetDynamicAreasForPoint':
+    'prefix': 'GetDynamicAreasForPoint'
+    'body': 'GetDynamicAreasForPoint(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:STREAMER_TAG_AREA areas[]}, ${5:maxareas = sizeof areas})'
+
+  'GetNumberDynamicAreasForPoint':
+    'prefix': 'GetNumberDynamicAreasForPoint'
+    'body': 'GetNumberDynamicAreasForPoint(${1:Float:x}, ${2:Float:y}, ${3:Float:z})'
+
+  'AttachDynamicAreaToObject':
+    'prefix': 'AttachDynamicAreaToObject'
+    'body': 'AttachDynamicAreaToObject(${1:STREAMER_TAG_AREA areaid}, ${2:STREAMER_TAG_OBJECT_ALT objectid}, ${3:type = STREAMER_OBJECT_TYPE_DYNAMIC}, ${4:playerid = INVALID_PLAYER_ID}, ${5:Float:offsetx = 0.0}, ${6:Float:offsety = 0.0}, ${7:Float:offsetz = 0.0})'
+
+  'AttachDynamicAreaToPlayer':
+    'prefix': 'AttachDynamicAreaToPlayer'
+    'body': 'AttachDynamicAreaToPlayer(${1:STREAMER_TAG_AREA areaid}, ${2:playerid}, ${3:Float:offsetx = 0.0}, ${4:Float:offsety = 0.0}, ${5:Float:offsetz = 0.0})'
+
+  'AttachDynamicAreaToVehicle':
+    'prefix': 'AttachDynamicAreaToVehicle'
+    'body': 'AttachDynamicAreaToVehicle(${1:STREAMER_TAG_AREA areaid}, ${2:vehicleid}, ${3:Float:offsetx = 0.0}, ${4:Float:offsety = 0.0}, ${5:Float:offsetz = 0.0})'
+
+  'CreateDynamicObjectEx':
+    'prefix': 'CreateDynamicObjectEx'
+    'body': 'CreateDynamicObjectEx(${1:modelid}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:Float:rx}, ${6:Float:ry}, ${7:Float:rz}, ${8:Float:streamdistance = STREAMER_OBJECT_SD}, ${9:Float:drawdistance = STREAMER_OBJECT_DD}, ${10:worlds[] = { -1 }}, ${11:interiors[] = { -1 }}, ${12:players[] = { -1 }}, ${13:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${14:maxworlds = sizeof worlds}, ${15:maxinteriors = sizeof interiors}, ${16:maxplayers = sizeof players}, ${17:maxareas = sizeof areas})'
+
+  'CreateDynamicPickupEx':
+    'prefix': 'CreateDynamicPickupEx'
+    'body': 'CreateDynamicPickupEx(${1:modelid}, ${2:type}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z}, ${6:Float:streamdistance = STREAMER_PICKUP_SD}, ${7:worlds[] = { -1 }}, ${8:interiors[] = { -1 }}, ${9:players[] = { -1 }}, ${10:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${11:maxworlds = sizeof worlds}, ${12:maxinteriors = sizeof interiors}, ${13:maxplayers = sizeof players}, ${14:maxareas = sizeof areas})'
+
+  'CreateDynamicCPEx':
+    'prefix': 'CreateDynamicCPEx'
+    'body': 'CreateDynamicCPEx(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:Float:size}, ${5:Float:streamdistance = STREAMER_CP_SD}, ${6:worlds[] = { -1 }}, ${7:interiors[] = { -1 }}, ${8:players[] = { -1 }}, ${9:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${10:maxworlds = sizeof worlds}, ${11:maxinteriors = sizeof interiors}, ${12:maxplayers = sizeof players}, ${13:maxareas = sizeof areas})'
+
+  'CreateDynamicRaceCPEx':
+    'prefix': 'CreateDynamicRaceCPEx'
+    'body': 'CreateDynamicRaceCPEx(${1:type}, ${2:Float:x}, ${3:Float:y}, ${4:Float:z}, ${5:Float:nextx}, ${6:Float:nexty}, ${7:Float:nextz}, ${8:Float:size}, ${9:Float:streamdistance = STREAMER_RACE_CP_SD}, ${10:worlds[] = { -1 }}, ${11:interiors[] = { -1 }}, ${12:players[] = { -1 }}, ${13:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${14:maxworlds = sizeof worlds}, ${15:maxinteriors = sizeof interiors}, ${16:maxplayers = sizeof players}, ${17:maxareas = sizeof areas})'
+
+  'CreateDynamicMapIconEx':
+    'prefix': 'CreateDynamicMapIconEx'
+    'body': 'CreateDynamicMapIconEx(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:type}, ${5:color}, ${6:style = MAPICON_LOCAL}, ${7:Float:streamdistance = STREAMER_MAP_ICON_SD}, ${8:worlds[] = { -1 }}, ${9:interiors[] = { -1 }}, ${10:players[] = { -1 }}, ${11:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${12:maxworlds = sizeof worlds}, ${13:maxinteriors = sizeof interiors}, ${14:maxplayers = sizeof players}, ${15:maxareas = sizeof areas})'
+
+  'CreateDynamic3DTextLabelEx':
+    'prefix': 'CreateDynamic3DTextLabelEx'
+    'body': 'CreateDynamic3DTextLabelEx(${1:const text[]}, ${2:color}, ${3:Float:x}, ${4:Float:y}, ${5:Float:z}, ${6:Float:drawdistance}, ${7:attachedplayer = INVALID_PLAYER_ID}, ${8:attachedvehicle = INVALID_VEHICLE_ID}, ${9:testlos = 0}, ${10:Float:streamdistance = STREAMER_3D_TEXT_LABEL_SD}, ${11:worlds[] = { -1 }}, ${12:interiors[] = { -1 }}, ${13:players[] = { -1 }}, ${14:STREAMER_TAG_AREA areas[] = { STREAMER_TAG_AREA -1 }}, ${15:maxworlds = sizeof worlds}, ${16:maxinteriors = sizeof interiors}, ${17:maxplayers = sizeof players}, ${18:maxareas = sizeof areas})'
+
+  'CreateDynamicCircleEx':
+    'prefix': 'CreateDynamicCircleEx'
+    'body': 'CreateDynamicCircleEx(${1:Float:x}, ${2:Float:y}, ${3:Float:size}, ${4:worlds[] = { -1 }}, ${5:interiors[] = { -1 }}, ${6:players[] = { -1 }}, ${7:maxworlds = sizeof worlds}, ${8:maxinteriors = sizeof interiors}, ${9:maxplayers = sizeof players})'
+
+  'CreateDynamicCylinderEx':
+    'prefix': 'CreateDynamicCylinderEx'
+    'body': 'CreateDynamicCylinderEx(${1:Float:x}, ${2:Float:y}, ${3:Float:minz}, ${4:Float:maxz}, ${5:Float:size}, ${6:worlds[] = { -1 }}, ${7:interiors[] = { -1 }}, ${8:players[] = { -1 }}, ${9:maxworlds = sizeof worlds}, ${10:maxinteriors = sizeof interiors}, ${11:maxplayers = sizeof players})'
+
+  'CreateDynamicSphereEx':
+    'prefix': 'CreateDynamicSphereEx'
+    'body': 'CreateDynamicSphereEx(${1:Float:x}, ${2:Float:y}, ${3:Float:z}, ${4:Float:size}, ${5:worlds[] = { -1 }}, ${6:interiors[] = { -1 }}, ${7:players[] = { -1 }}, ${8:maxworlds = sizeof worlds}, ${9:maxinteriors = sizeof interiors}, ${10:maxplayers = sizeof players})'
+
+  'CreateDynamicRectangleEx':
+    'prefix': 'CreateDynamicRectangleEx'
+    'body': 'CreateDynamicRectangleEx(${1:Float:minx}, ${2:Float:miny}, ${3:Float:maxx}, ${4:Float:maxy}, ${5:worlds[] = { -1 }}, ${6:interiors[] = { -1 }}, ${7:players[] = { -1 }}, ${8:maxworlds = sizeof worlds}, ${9:maxinteriors = sizeof interiors}, ${10:maxplayers = sizeof players})'
+
+  'CreateDynamicCuboidEx':
+    'prefix': 'CreateDynamicCuboidEx'
+    'body': 'CreateDynamicCuboidEx(${1:Float:minx}, ${2:Float:miny}, ${3:Float:minz}, ${4:Float:maxx}, ${5:Float:maxy}, ${6:Float:maxz}, ${7:worlds[] = { -1 }}, ${8:interiors[] = { -1 }}, ${9:players[] = { -1 }}, ${10:maxworlds = sizeof worlds}, ${11:maxinteriors = sizeof interiors}, ${12:maxplayers = sizeof players})'
+
+  'CreateDynamicCubeEx':
+    'prefix': 'CreateDynamicCubeEx'
+    'body': 'CreateDynamicCubeEx(${1:Float:minx}, ${2:Float:miny}, ${3:Float:minz}, ${4:Float:maxx}, ${5:Float:maxy}, ${6:Float:maxz}, ${7:worlds[] = { -1 }}, ${8:interiors[] = { -1 }}, ${9:players[] = { -1 }}, ${10:maxworlds = sizeof worlds}, ${11:maxinteriors = sizeof interiors}, ${12:maxplayers = sizeof players})'
+
+  'CreateDynamicPolygonEx':
+    'prefix': 'CreateDynamicPolygonEx'
+    'body': 'CreateDynamicPolygonEx(${1:Float:points[]}, ${2:Float:minz = -FLOAT_INFINITY}, ${3:Float:maxz = FLOAT_INFINITY}, ${4:maxpoints = sizeof points}, ${5:worlds[] = { -1 }}, ${6:interiors[] = { -1 }}, ${7:players[] = { -1 }}, ${8:maxworlds = sizeof worlds}, ${9:maxinteriors = sizeof interiors}, ${10:maxplayers = sizeof players})'
+
+  'Streamer_TickRate':
+    'prefix': 'Streamer_TickRate'
+    'body': 'Streamer_TickRate(${1:rate})'
+
+  'Streamer_MaxItems':
+    'prefix': 'Streamer_MaxItems'
+    'body': 'Streamer_MaxItems(${1:type}, ${2:items})'
+
+  'Streamer_VisibleItems':
+    'prefix': 'Streamer_VisibleItems'
+    'body': 'Streamer_VisibleItems(${1:type}, ${2:items}, ${3:playerid = -1})'
+
+  'Streamer_CellDistance':
+    'prefix': 'Streamer_CellDistance'
+    'body': 'Streamer_CellDistance(${1:Float:distance})'
+
+  'Streamer_CellSize':
+    'prefix': 'Streamer_CellSize'
+    'body': 'Streamer_CellSize(${1:Float:size})'
+
+  'Streamer_CallbackHook':
+    'prefix': 'Streamer_CallbackHook'
+    'body': 'Streamer_CallbackHook(${1:callback}, ${2:...})'
+
+  'DestroyAllDynamicObjects':
+    'prefix': 'DestroyAllDynamicObjects'
+    'body': 'DestroyAllDynamicObjects()'
+
+  'CountDynamicObjects':
+    'prefix': 'CountDynamicObjects'
+    'body': 'CountDynamicObjects()'
+
+  'DestroyAllDynamicPickups':
+    'prefix': 'DestroyAllDynamicPickups'
+    'body': 'DestroyAllDynamicPickups()'
+
+  'CountDynamicPickups':
+    'prefix': 'CountDynamicPickups'
+    'body': 'CountDynamicPickups()'
+
+  'DestroyAllDynamicCPs':
+    'prefix': 'DestroyAllDynamicCPs'
+    'body': 'DestroyAllDynamicCPs()'
+
+  'CountDynamicCPs':
+    'prefix': 'CountDynamicCPs'
+    'body': 'CountDynamicCPs()'
+
+  'DestroyAllDynamicRaceCPs':
+    'prefix': 'DestroyAllDynamicRaceCPs'
+    'body': 'DestroyAllDynamicRaceCPs()'
+
+  'CountDynamicRaceCPs':
+    'prefix': 'CountDynamicRaceCPs'
+    'body': 'CountDynamicRaceCPs()'
+
+  'DestroyAllDynamicMapIcons':
+    'prefix': 'DestroyAllDynamicMapIcons'
+    'body': 'DestroyAllDynamicMapIcons()'
+
+  'CountDynamicMapIcons':
+    'prefix': 'CountDynamicMapIcons'
+    'body': 'CountDynamicMapIcons()'
+
+  'DestroyAllDynamic3DTextLabels':
+    'prefix': 'DestroyAllDynamic3DTextLabels'
+    'body': 'DestroyAllDynamic3DTextLabels()'
+
+  'CountDynamic3DTextLabels':
+    'prefix': 'CountDynamic3DTextLabels'
+    'body': 'CountDynamic3DTextLabels()'
+
+  'DestroyAllDynamicAreas':
+    'prefix': 'DestroyAllDynamicAreas'
+    'body': 'DestroyAllDynamicAreas()'
+
+  'CountDynamicAreas':
+    'prefix': 'CountDynamicAreas'
+    'body': 'CountDynamicAreas()'
+
+  'OnDynamicObjectMoved':
+    'prefix': 'OnDynamicObjectMoved'
+    'body': 'OnDynamicObjectMoved(${1:STREAMER_TAG_OBJECT objectid})'
+
+  'OnPlayerEditDynamicObject':
+    'prefix': 'OnPlayerEditDynamicObject'
+    'body': 'OnPlayerEditDynamicObject(${1:playerid}, ${2:STREAMER_TAG_OBJECT objectid}, ${3:response}, ${4:Float:x}, ${5:Float:y}, ${6:Float:z}, ${7:Float:rx}, ${8:Float:ry}, ${9:Float:rz})'
+
+  'OnPlayerSelectDynamicObject':
+    'prefix': 'OnPlayerSelectDynamicObject'
+    'body': 'OnPlayerSelectDynamicObject(${1:playerid}, ${2:STREAMER_TAG_OBJECT objectid}, ${3:modelid}, ${4:Float:x}, ${5:Float:y}, ${6:Float:z})'
+
+  'OnPlayerShootDynamicObject':
+    'prefix': 'OnPlayerShootDynamicObject'
+    'body': 'OnPlayerShootDynamicObject(${1:playerid}, ${2:weaponid}, ${3:STREAMER_TAG_OBJECT objectid}, ${4:Float:x}, ${5:Float:y}, ${6:Float:z})'
+
+  'OnPlayerPickUpDynamicPickup':
+    'prefix': 'OnPlayerPickUpDynamicPickup'
+    'body': 'OnPlayerPickUpDynamicPickup(${1:playerid}, ${2:STREAMER_TAG_PICKUP pickupid})'
+
+  'OnPlayerEnterDynamicCP':
+    'prefix': 'OnPlayerEnterDynamicCP'
+    'body': 'OnPlayerEnterDynamicCP(${1:playerid}, ${2:STREAMER_TAG_CP checkpointid})'
+
+  'OnPlayerLeaveDynamicCP':
+    'prefix': 'OnPlayerLeaveDynamicCP'
+    'body': 'OnPlayerLeaveDynamicCP(${1:playerid}, ${2:STREAMER_TAG_CP checkpointid})'
+
+  'OnPlayerEnterDynamicRaceCP':
+    'prefix': 'OnPlayerEnterDynamicRaceCP'
+    'body': 'OnPlayerEnterDynamicRaceCP(${1:playerid}, ${2:STREAMER_TAG_RACE_CP checkpointid})'
+
+  'OnPlayerLeaveDynamicRaceCP':
+    'prefix': 'OnPlayerLeaveDynamicRaceCP'
+    'body': 'OnPlayerLeaveDynamicRaceCP(${1:playerid}, ${2:STREAMER_TAG_RACE_CP checkpointid})'
+
+  'OnPlayerEnterDynamicArea':
+    'prefix': 'OnPlayerEnterDynamicArea'
+    'body': 'OnPlayerEnterDynamicArea(${1:playerid}, ${2:STREAMER_TAG_AREA areaid})'
+
+  'OnPlayerLeaveDynamicArea':
+    'prefix': 'OnPlayerLeaveDynamicArea'
+    'body': 'OnPlayerLeaveDynamicArea(${1:playerid}, ${2:STREAMER_TAG_AREA areaid})'
+
+  'Streamer_OnPluginError':
+    'prefix': 'Streamer_OnPluginError'
+    'body': 'Streamer_OnPluginError(${1:error[]})'


### PR DESCRIPTION
- Added ALS (function/callback/script init/script exit) snippets;
- Added crashdetect snippets;
- Added FCNPC snippets;
- Added file snippets;
- Addes GVar snippets;
- Added Incognito's Streamer snippets;
- Added IRC snippets;
- Added SIF library snippets;
- Added Socket plugin snippets;
- Added sscanf2 snippets;

All those snippets were converted from [Southclaw's Sublime
Autocompletions](https://github.com/Southclaw/pawn-sublime-language). I have more (from Southclaw's repo), but I decided to commit the most importants.

Note: Yes, is possible use all snippets in separated files!